### PR TITLE
SFX-99: Add Core module with registration mechanism

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,5 +4,5 @@
     "source-map-support/register"
   ],
   "recursive": true,
-  "spec": ["test/setup.ts", "test/unit/common/*.test.ts", "test/unit/node/*.test.ts"]
+  "spec": ["test/setup.ts", "test/unit/common/**/*.test.ts", "test/unit/node/**/*.test.ts"]
 }

--- a/packages/@sfx/core/CHANGELOG.md
+++ b/packages/@sfx/core/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- SFX-99: Added the Core module and related plugin interfaces.
+  - The Core module manages the registration and unregistration of plugins.
+  - The package also exports the Plugin, PluginMetadata, and PluginRegistry interfaces.

--- a/packages/@sfx/core/CHANGELOG.md
+++ b/packages/@sfx/core/CHANGELOG.md
@@ -6,6 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- SFX-99: Added the Core module and related plugin interfaces.
+- SFX-99: Added the `Core` module and related plugin interfaces.
   - The Core module manages the registration and unregistration of plugins.
-  - The package also exports the Plugin, PluginMetadata, and PluginRegistry interfaces.
+  - The package also exports the `Plugin`, `PluginMetadata`, and `PluginRegistry` interfaces.

--- a/packages/@sfx/core/README.md
+++ b/packages/@sfx/core/README.md
@@ -1,1 +1,27 @@
 # SF-X Core
+
+This package contains the SF-X Core class and related plugin interfaces.
+
+## Usage
+
+To use Core, simply instantiate it:
+
+```js
+const core = new Core();
+```
+
+## Registering a plugin
+
+To register one or more plugins with Core, instantiate the plugins, then
+pass them to `Core.register()`:
+
+```js
+const core = new Core();
+const pluginA = new PluginA();
+const pluginB = new PluginB();
+
+core.register([pluginA, pluginB]);
+```
+
+A plugin may take configuration options in its constructor. Refer to the
+plugin's documentation for details.

--- a/packages/@sfx/core/README.md
+++ b/packages/@sfx/core/README.md
@@ -1,0 +1,1 @@
+# SF-X Core

--- a/packages/@sfx/core/karma.conf.js
+++ b/packages/@sfx/core/karma.conf.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../karma.conf.js');

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sfx/core",
+  "version": "0.0.0",
+  "description": "",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "../../../scripts/build.sh",
+    "dev": "nodemon --config ../../../nodemon.json --exec npm run build",
+    "test": "nyc mocha",
+    "tdd": "nodemon --config ../../../nodemon.test.json --exec npm test",
+    "test:browser": "karma start karma.conf.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/groupby/sfx-logic.git",
+    "directory": "packages/@sfx/core"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -16,5 +16,8 @@
     "directory": "packages/@sfx/core"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "mocha": {
+    "require": ["../../../test-setup.ts"]
+  }
 }

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",
     "test": "nyc mocha",
     "tdd": "nodemon --config ../../../nodemon.test.json --exec npm test",
-    "test:browser": "karma start karma.conf.js"
+    "test:browser": "karma start karma.conf.js",
+    "tdd:browser": "karma start karma.conf.js --no-single-run"
   },
   "repository": {
     "type": "git",
@@ -16,8 +17,5 @@
     "directory": "packages/@sfx/core"
   },
   "author": "",
-  "license": "MIT",
-  "mocha": {
-    "spec": ["../../../test-setup.ts"]
-  }
+  "license": "MIT"
 }

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "SF-X Core",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../../scripts/build.sh",
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -2,7 +2,7 @@
   "name": "@sfx/core",
   "version": "0.0.0",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "scripts": {
     "build": "../../../scripts/build.sh",
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sfx/core",
   "version": "0.0.0",
-  "description": "",
+  "description": "SF-X Core",
   "main": "dist/index.js",
   "scripts": {
     "build": "../../../scripts/build.sh",

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -19,5 +19,6 @@
     "directory": "packages/@sfx/core"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "sideEffects": false
 }

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -18,6 +18,6 @@
   "author": "",
   "license": "MIT",
   "mocha": {
-    "require": ["../../../test-setup.ts"]
+    "spec": ["../../../test-setup.ts"]
   }
 }

--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -4,6 +4,7 @@
   "description": "SF-X Core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "esnext": "esnext/index.js",
   "scripts": {
     "build": "../../../scripts/build.sh",
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,2 +1,14 @@
+import { Plugin } from './plugin';
+
 export default class Core {
+  plugins = Object.create(null);
+
+  /**
+   * Register one or more plugins with Core.
+   *
+   * @param plugins An array of plugin instances to regsiter.
+   */
+  register(plugins: Plugin[]) {
+    plugins.forEach((p) => p.register(this.plugins));
+  }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -6,11 +6,43 @@ import {
   registerPlugins,
 } from './utils/core';
 
+/**
+ * The core of the SF-X plugin system. This entity is responsible for
+ * managing plugins and provides a mechanism for plugins to communicate
+ * with each other.
+ */
 export default class Core {
+  /**
+   * The plugin registry. This object is a dictionary containing plugin
+   * names as keys and their corresponding exposed values as values.
+   *
+   * The preferred way to access plugins in the registry is through
+   * another plugin. Accessing the plugins through Core outside of a
+   * plugin is discouraged.
+   */
   plugins: PluginRegistry = Object.create(null);
 
   /**
    * Register one or more plugins with Core.
+   *
+   * Plugins given here are registered as a batch: the next lifecycle
+   * event does not occur until all plugins in this batch have
+   * experienced the current lifecycle event.
+   *
+   * The registration lifecycle is as follows:
+   *
+   * 1. **Registration:** The registry is populated with each plugin's
+   *    name and the value that it wants to expose. Plugins cannot
+   *    assume that other plugins have been registered.
+   * 2. **Initialization:** Plugins perform setup tasks. Plugins are
+   *    aware of the existence of other plugins, but should not make use
+   *    of their functionality as they may not yet be initialized.
+   * 3. **Ready:** Plugins may make use of other plugins.
+   *
+   * This function ensures that all plugin dependencies are available
+   * before proceeding to register the plugins. Circular dependencies
+   * are supported. If dependencies are missing, an error will be
+   * thrown.
    *
    * @param plugins An array of plugin instances to regsiter.
    */

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,4 +1,5 @@
 import { Plugin } from './plugin';
+import { calculateMissingDependencies } from './utils/core';
 
 export default class Core {
   plugins = Object.create(null);
@@ -9,6 +10,10 @@ export default class Core {
    * @param plugins An array of plugin instances to regsiter.
    */
   register(plugins: Plugin[]) {
+    const missingDependencies = calculateMissingDependencies(plugins, this.plugins);
+    if (missingDependencies.length) {
+      throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
+    }
     // ensure dependencies are valid
       // if not, exit/throw
     // call lifecycle methods on plugins

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -17,10 +17,10 @@ export default class Core {
    * names as keys and their corresponding exposed values as values.
    *
    * The preferred way to access plugins in the registry is through
-   * another plugin. Accessing the plugins through Core outside of a
+   * another plugin. Accessing the registry through Core outside of a
    * plugin is discouraged.
    */
-  plugins: PluginRegistry = Object.create(null);
+  registry: PluginRegistry = Object.create(null);
 
   /**
    * Register one or more plugins with Core.
@@ -47,12 +47,12 @@ export default class Core {
    * @param plugins An array of plugin instances to register.
    */
   register(plugins: Plugin[]) {
-    const missingDependencies = calculateMissingDependencies(plugins, this.plugins);
+    const missingDependencies = calculateMissingDependencies(plugins, this.registry);
     if (missingDependencies.length) {
       throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
     }
 
-    registerPlugins(plugins, this.plugins);
+    registerPlugins(plugins, this.registry);
     initPlugins(plugins);
     readyPlugins(plugins);
   }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -37,7 +37,8 @@ export default class Core {
    * 2. **Initialization:** Plugins perform setup tasks. Plugins are
    *    aware of the existence of other plugins, but should not make use
    *    of their functionality as they may not yet be initialized.
-   * 3. **Ready:** Plugins may make use of other plugins.
+   * 3. **Ready:** Registration is complete. All plugins have been
+   *    initialized, and plugins may make use of other plugins.
    *
    * This function ensures that all plugin dependencies are available
    * before proceeding to register the plugins. Circular dependencies

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,0 +1,2 @@
+export default class Core {
+}

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,4 +1,4 @@
-import { Plugin } from './plugin';
+import { Plugin, PluginRegistry } from './plugin';
 import {
   calculateMissingDependencies,
   initPlugins,
@@ -7,7 +7,7 @@ import {
 } from './utils/core';
 
 export default class Core {
-  plugins = Object.create(null);
+  plugins: PluginRegistry = Object.create(null);
 
   /**
    * Register one or more plugins with Core.

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,5 +1,10 @@
 import { Plugin } from './plugin';
-import { calculateMissingDependencies } from './utils/core';
+import {
+  calculateMissingDependencies,
+  initPlugins,
+  readyPlugins,
+  registerPlugins,
+} from './utils/core';
 
 export default class Core {
   plugins = Object.create(null);
@@ -14,8 +19,9 @@ export default class Core {
     if (missingDependencies.length) {
       throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
     }
-    // ensure dependencies are valid
-      // if not, exit/throw
-    // call lifecycle methods on plugins
+
+    registerPlugins(plugins, this.plugins);
+    initPlugins(plugins);
+    readyPlugins(plugins);
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -9,6 +9,8 @@ export default class Core {
    * @param plugins An array of plugin instances to regsiter.
    */
   register(plugins: Plugin[]) {
-    plugins.forEach((p) => p.register(this.plugins));
+    // ensure dependencies are valid
+      // if not, exit/throw
+    // call lifecycle methods on plugins
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -44,7 +44,7 @@ export default class Core {
    * are supported. If dependencies are missing, an error will be
    * thrown.
    *
-   * @param plugins An array of plugin instances to regsiter.
+   * @param plugins An array of plugin instances to register.
    */
   register(plugins: Plugin[]) {
     const missingDependencies = calculateMissingDependencies(plugins, this.plugins);

--- a/packages/@sfx/core/src/index.ts
+++ b/packages/@sfx/core/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './core';

--- a/packages/@sfx/core/src/index.ts
+++ b/packages/@sfx/core/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './core';
+export { Plugin, PluginMetadata } from './plugin';

--- a/packages/@sfx/core/src/index.ts
+++ b/packages/@sfx/core/src/index.ts
@@ -1,2 +1,2 @@
 export { default } from './core';
-export { Plugin, PluginMetadata } from './plugin';
+export { Plugin, PluginMetadata, PluginRegistry } from './plugin';

--- a/packages/@sfx/core/src/index.ts
+++ b/packages/@sfx/core/src/index.ts
@@ -1,2 +1,2 @@
-export { default } from './core';
+export { default as Core } from './core';
 export { Plugin, PluginMetadata, PluginRegistry } from './plugin';

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,6 +1,7 @@
 export interface Plugin {
   metadata: PluginMetadata;
   register(plugins: object): any;
+  init?: () => void;
 }
 
 export interface PluginMetadata {

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,3 +1,8 @@
 export interface Plugin {
+  metadata: PluginMetadata;
   register(plugins: object): any;
+}
+
+export interface PluginMetadata {
+  name: string;
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,0 +1,3 @@
+export interface Plugin {
+  register(plugins: object): any;
+}

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -48,7 +48,7 @@ export interface Plugin {
    * The callback for the ready phase of the lifecycle.
    *
    * In this function, the plugin can assume that other plugins have
-   * been initialized.
+   * been initialized and may safely use other plugins.
    */
   ready?: () => void;
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,6 +1,6 @@
 export interface Plugin {
   metadata: PluginMetadata;
-  register: (plugins: object) => any;
+  register: (plugins: PluginRegistry) => any;
   init?: () => void;
   ready?: () => void;
 }
@@ -8,4 +8,8 @@ export interface Plugin {
 export interface PluginMetadata {
   name: string;
   depends: string[];
+}
+
+export interface PluginRegistry {
+  [key: string]: any;
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -7,4 +7,5 @@ export interface Plugin {
 
 export interface PluginMetadata {
   name: string;
+  depends: [];
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -7,5 +7,5 @@ export interface Plugin {
 
 export interface PluginMetadata {
   name: string;
-  depends: [];
+  depends: string[];
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,15 +1,83 @@
+/**
+ * A plugin for use with the SF-X Core. Plugins supply functionality to
+ * the otherwise function-less Core. Plugins may depend on other
+ * plugins.
+ *
+ * A plugin must conform to this interface to be registered with Core,
+ * but it may define other methods and properties for internal use.
+ */
 export interface Plugin {
+  /**
+   * Plugin metadata. This object provides Core with the information
+   * necessary to register the plugin.
+   *
+   * Plugin authors may consider using a getter to implement this
+   * property.
+   */
   metadata: PluginMetadata;
+
+  /**
+   * The callback for the registration phase of the lifecycle. The
+   * plugin will receive a reference to the plugin registry (the object
+   * through which other plugins can be accessed) here, and the function
+   * is expected to return a value that will be exposed through the same
+   * registry. It is recommended to store a reference to both values in
+   * the plugin for later retrieval.
+   *
+   * The plugin cannot assume that other plugins are registered in this
+   * function.
+   *
+   * @param plugins The plugin registry containing all other plugins.
+   * @returns The value to expose in the registry.
+   */
   register: (plugins: PluginRegistry) => any;
+
+  /**
+   * The callback for the initialization phase of the lifecycle. The
+   * plugin should do as much setup as it can in this function.
+   *
+   * In this function, the plugin can assume that other plugins have
+   * been registered and are accessible through the plugin registry
+   * object given in the `register` function, but it cannot assume that
+   * the other plugins have been initialized. In other words, the plugin
+   * will know which plugins are available, but it cannot use them.
+   */
   init?: () => void;
+
+  /**
+   * The callback for the ready phase of the lifecycle.
+   *
+   * In this function, the plugin can assume that other plugins have
+   * been initialized.
+   */
   ready?: () => void;
 }
 
+/**
+ * Plugin metadata. Core will use the properties specified in this
+ * interface during the registration process.
+ */
 export interface PluginMetadata {
+  /**
+   * The name of the plugin. This name will be used as the key in the
+   * registry, so this name should be unique. By convention, this name
+   * should be a valid JavaScript identifier and be written in
+   * snake_case.
+   */
   name: string;
+
+  /**
+   * The names of all the plugins that this plugin has a hard dependency
+   * on (i.e. these plugins must be present for this plugin to
+   * function).
+   */
   depends: string[];
 }
 
+/**
+ * The type of the plugin registry. Each key/value pair corresponds to
+ * the name of a plugin and its exposed value.
+ */
 export interface PluginRegistry {
   [key: string]: any;
 }

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -2,6 +2,7 @@ export interface Plugin {
   metadata: PluginMetadata;
   register(plugins: object): any;
   init?: () => void;
+  ready?: () => void;
 }
 
 export interface PluginMetadata {

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -1,6 +1,6 @@
 export interface Plugin {
   metadata: PluginMetadata;
-  register(plugins: object): any;
+  register: (plugins: object) => any;
   init?: () => void;
   ready?: () => void;
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -39,3 +39,14 @@ export function initPlugins(plugins: Plugin[]) {
     }
   });
 }
+
+/**
+ * TODO
+ */
+export function readyPlugins(plugins: Plugin[]) {
+  plugins.forEach((plugin) => {
+    if (typeof plugin.ready === 'function') {
+      plugin.ready();
+    }
+  });
+}

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -28,3 +28,14 @@ export function registerPlugins(plugins: Plugin[], registry: object) {
 
   return newlyRegistered;
 }
+
+/**
+ * TODO
+ */
+export function initPlugins(plugins: Plugin[]) {
+  plugins.forEach((plugin) => {
+    if (typeof plugin.init === 'function') {
+      plugin.init();
+    }
+  });
+}

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,2 +1,9 @@
-export function checkDependencies() {
+export function checkDependencies(available: string[], required: string[]) {
+  const availableSet = new Set(available);
+  const requiredSet = new Set(required);
+  const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
+
+  if (difference.size) {
+    throw new Error('Unmet dependencies: ' + Array.from(difference.values()).sort().join(', '));
+  }
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '../plugin';
+import { Plugin, PluginRegistry } from '../plugin';
 
 /**
  * Calculates the missing dependencies of the given plugins. The given
@@ -31,11 +31,11 @@ export function calculateMissingDependencies(plugins: Plugin[], registry: object
  * each plugin are added to the given registry.
  *
  * @param plugins The plugins to register.
- * @param regsitry The registry to register the plugins into.
- * @returns an Object containing the keys and values of the new items
+ * @param registry The registry into which to add the plugins.
+ * @returns An object containing the keys and values of the new items
  * added to the registry.
  */
-export function registerPlugins(plugins: Plugin[], registry: object) {
+export function registerPlugins(plugins: Plugin[], registry: PluginRegistry): PluginRegistry {
   const newlyRegistered = Object.create(null);
 
   plugins.forEach((plugin) => {

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,3 +1,5 @@
+import { Plugin } from '../plugin';
+
 /**
  * TODO
  */
@@ -7,4 +9,22 @@ export function getMissingDependencies(available: string[], required: string[]):
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
 
   return Array.from(difference.values()).sort();
+}
+
+/**
+ * TODO
+ */
+export function registerPlugins(plugins: Plugin[], registry: object) {
+  const newlyRegistered = Object.create(null);
+
+  plugins.forEach((plugin) => {
+    const exposedValue = plugin.register(registry);
+    const { name } = plugin.metadata;
+
+    newlyRegistered[name] = exposedValue;
+  });
+
+  Object.assign(registry, newlyRegistered);
+
+  return newlyRegistered;
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,3 +1,6 @@
+/**
+ * TODO
+ */
 export function getMissingDependencies(available: string[], required: string[]): string[] {
   const availableSet = new Set(available);
   const requiredSet = new Set(required);

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -3,8 +3,11 @@ import { Plugin } from '../plugin';
 /**
  * TODO
  */
-export function getMissingDependencies(available: string[], required: string[]): string[] {
-  const availableSet = new Set(available);
+export function getMissingDependencies(plugins: Plugin[], registry: object): string[] {
+  const availableSet = new Set(Object.keys(registry));
+  const required = plugins.reduce((memo: [], plugin: Plugin) => {
+    return [...memo, ...plugin.metadata.depends];
+  }, [])
   const requiredSet = new Set(required);
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
 

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,0 +1,2 @@
+export function checkDependencies() {
+}

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -51,8 +51,7 @@ export function registerPlugins(plugins: Plugin[], registry: PluginRegistry): Pl
 }
 
 /**
- * Calls the `init` function of each plugin. If a plugin does not
- * exppose an `init` function, it is ignored.
+ * Calls the optional `init` function of each plugin.
  *
  * @param plugins The plugins to initialize.
  */
@@ -65,8 +64,7 @@ export function initPlugins(plugins: Plugin[]) {
 }
 
 /**
- * Calls the `ready` function of each plugin. If a plugin does not
- * expose a `ready` function, it is ignored.
+ * Calls the optional `ready` function of each plugin.
  *
  * @param plugins The plugins to ready.
  */

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -10,8 +10,9 @@ export function calculateMissingDependencies(plugins: Plugin[], registry: object
   ];
   const availableSet = new Set(available);
 
+  const required = plugins.reduce((memo, plugin) => {
     return [...memo, ...plugin.metadata.depends];
-  }, [])
+  }, []);
   const requiredSet = new Set(required);
 
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -39,7 +39,7 @@ export function registerPlugins(plugins: Plugin[], registry: object) {
   const newlyRegistered = Object.create(null);
 
   plugins.forEach((plugin) => {
-    const exposedValue = plugin.register(registry);
+    const exposedValue = plugin.register(Object.create(registry));
     const { name } = plugin.metadata;
 
     newlyRegistered[name] = exposedValue;

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -3,7 +3,7 @@ import { Plugin } from '../plugin';
 /**
  * TODO
  */
-export function getMissingDependencies(plugins: Plugin[], registry: object): string[] {
+export function calculateMissingDependencies(plugins: Plugin[], registry: object): string[] {
   const availableSet = new Set(Object.keys(registry));
   const required = plugins.reduce((memo: [], plugin: Plugin) => {
     return [...memo, ...plugin.metadata.depends];

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,7 +1,13 @@
 import { Plugin } from '../plugin';
 
 /**
- * TODO
+ * Calculates the missing dependencies of the given plugins. The given
+ * plugins and the plugins in the registry are eligible to satisfy
+ * dependencies.
+ *
+ * @param plugins The plugins whose dependencies should be checked.
+ * @param registry The plugin registry containing all available plugins.
+ * @returns an Array of names of missing plugins.
  */
 export function calculateMissingDependencies(plugins: Plugin[], registry: object): string[] {
   const available = [
@@ -21,7 +27,13 @@ export function calculateMissingDependencies(plugins: Plugin[], registry: object
 }
 
 /**
- * TODO
+ * Calls the `register` function of each plugin. The values returned by
+ * each plugin are added to the given registry.
+ *
+ * @param plugins The plugins to register.
+ * @param regsitry The registry to register the plugins into.
+ * @returns an Object containing the keys and values of the new items
+ * added to the registry.
  */
 export function registerPlugins(plugins: Plugin[], registry: object) {
   const newlyRegistered = Object.create(null);
@@ -39,7 +51,10 @@ export function registerPlugins(plugins: Plugin[], registry: object) {
 }
 
 /**
- * TODO
+ * Calls the `init` function of each plugin. If a plugin does not
+ * exppose an `init` function, it is ignored.
+ *
+ * @param plugins The plugins to initialize.
  */
 export function initPlugins(plugins: Plugin[]) {
   plugins.forEach((plugin) => {
@@ -50,7 +65,10 @@ export function initPlugins(plugins: Plugin[]) {
 }
 
 /**
- * TODO
+ * Calls the `ready` function of each plugin. If a plugin does not
+ * expose a `ready` function, it is ignored.
+ *
+ * @param plugins The plugins to ready.
  */
 export function readyPlugins(plugins: Plugin[]) {
   plugins.forEach((plugin) => {

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -6,8 +6,8 @@ import { Plugin, PluginRegistry } from '../plugin';
  * dependencies.
  *
  * @param plugins The plugins whose dependencies should be checked.
- * @param registry The plugin registry containing all available plugins.
- * @returns an Array of names of missing plugins.
+ * @param registry The plugin registry containing all registered plugins.
+ * @returns An array of names of missing plugins.
  */
 export function calculateMissingDependencies(plugins: Plugin[], registry: object): string[] {
   const available = [

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,9 +1,7 @@
-export function checkDependencies(available: string[], required: string[]) {
+export function getMissingDependencies(available: string[], required: string[]): string[] {
   const availableSet = new Set(available);
   const requiredSet = new Set(required);
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
 
-  if (difference.size) {
-    throw new Error('Unmet dependencies: ' + Array.from(difference.values()).sort().join(', '));
-  }
+  return Array.from(difference.values()).sort();
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -4,11 +4,16 @@ import { Plugin } from '../plugin';
  * TODO
  */
 export function calculateMissingDependencies(plugins: Plugin[], registry: object): string[] {
-  const availableSet = new Set(Object.keys(registry));
-  const required = plugins.reduce((memo: [], plugin: Plugin) => {
+  const available = [
+    ...Object.keys(registry),
+    ...plugins.map(({ metadata: { name }}) => name),
+  ];
+  const availableSet = new Set(available);
+
     return [...memo, ...plugin.metadata.depends];
   }, [])
   const requiredSet = new Set(required);
+
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
 
   return Array.from(difference.values()).sort();

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -14,13 +14,11 @@ export function calculateMissingDependencies(plugins: Plugin[], registry: Plugin
     ...Object.keys(registry),
     ...plugins.map(({ metadata: { name }}) => name),
   ];
-  const availableSet = new Set(available);
-
   const required = plugins.reduce((memo, plugin) => {
     return [...memo, ...plugin.metadata.depends];
   }, []);
+  const availableSet = new Set(available);
   const requiredSet = new Set(required);
-
   const difference = new Set(Array.from(requiredSet).filter((p) => !availableSet.has(p)));
 
   return Array.from(difference.values()).sort();
@@ -46,7 +44,6 @@ export function registerPlugins(plugins: Plugin[], registry: PluginRegistry): Pl
   });
 
   Object.assign(registry, newlyRegistered);
-
   return newlyRegistered;
 }
 

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -9,7 +9,7 @@ import { Plugin, PluginRegistry } from '../plugin';
  * @param registry The plugin registry containing all registered plugins.
  * @returns An array of names of missing plugins.
  */
-export function calculateMissingDependencies(plugins: Plugin[], registry: object): string[] {
+export function calculateMissingDependencies(plugins: Plugin[], registry: PluginRegistry): string[] {
   const available = [
     ...Object.keys(registry),
     ...plugins.map(({ metadata: { name }}) => name),

--- a/packages/@sfx/core/test/setup.ts
+++ b/packages/@sfx/core/test/setup.ts
@@ -1,0 +1,1 @@
+import '../../../../test/setup';

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -17,10 +17,10 @@ describe('Core', () => {
   });
 
   describe('register()', () => {
-    let calculateMissingDependencies = stub(CoreUtils, 'calculateMissingDependencies').returns(['x']);
-    let registerPlugins = stub(CoreUtils, 'registerPlugins');
-    let initPlugins = stub(CoreUtils, 'initPlugins');
-    let readyPlugins = stub(CoreUtils, 'readyPlugins');
+    let calculateMissingDependencies;
+    let registerPlugins;
+    let initPlugins;
+    let readyPlugins;
 
     beforeEach(() => {
       calculateMissingDependencies = stub(CoreUtils, 'calculateMissingDependencies');

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,8 +1,35 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import Core from '../../../src/core';
 
 describe('Core', () => {
-  it('should be a class', () => {
-    expect(Core).to.be.a('function');
+  let core: Core;
+
+  beforeEach(() => {
+    core = new Core();
+  });
+
+  describe('constructor()', () => {
+    it('should create an empty null-prototype plugins object', () => {
+      expect(core.plugins).to.be.empty;
+      expect(Object.getPrototypeOf(core.plugins)).to.be.null;
+    });
+  });
+
+  describe('register()', () => {
+    it('should call the register() function of each plugin', () => {
+      const registerA = spy();
+      const registerB = spy();
+      const plugins = [
+        { register: registerA },
+        { register: registerB },
+      ];
+
+      core.register(plugins);
+
+      expect(registerA).to.be.calledWith(core.plugins);
+      expect(registerB).to.be.calledWith(core.plugins);
+      expect(registerB).to.be.calledAfter(registerA);
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -29,7 +29,22 @@ describe('Core', () => {
 
       expect(registerA).to.be.calledWith(core.plugins);
       expect(registerB).to.be.calledWith(core.plugins);
-      expect(registerB).to.be.calledAfter(registerA);
+    });
+
+    it('should call the register() functions of each plugin in order',() => {
+      const registerA = spy();
+      const registerB = spy();
+      const registerC = spy();
+      const plugins = [
+        { register: registerA },
+        { register: registerB },
+        { register: registerC },
+      ];
+
+      core.register(plugins);
+
+      expect(registerA).to.be.calledBefore(registerB);
+      expect(registerB).to.be.calledBefore(registerC);
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -10,9 +10,15 @@ describe('Core', () => {
   });
 
   describe('constructor()', () => {
-    it('should create an empty null-prototype plugins object', () => {
+    it('should create an empty null-prototype plugins registry object', () => {
       expect(core.plugins).to.be.empty;
       expect(Object.getPrototypeOf(core.plugins)).to.be.null;
     });
   });
+
+  // describe('register()', () => {
+  //   it('should throw if dependencies are not met', () => {
+
+  //   });
+  // })
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import Core from '../../../src/core';
+
+describe('Core', () => {
+  it('should be a class', () => {
+    expect(Core).to.be.a('function');
+  });
+});

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -71,7 +71,6 @@ describe('Core', () => {
       core.register(plugins);
 
       expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.registry));
-      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.registry));
       expect(initPlugins).to.be.calledWith(plugins);
       expect(readyPlugins).to.be.calledWith(plugins);
       sinon.assert.callOrder(

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,4 +1,4 @@
-import { expect, sinon, spy, stub } from '../../utils';
+import { expect, sinon, stub } from '../../utils';
 import Core from '../../../src/core';
 import * as CoreUtils from '../../../src/utils/core';
 

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -15,36 +15,4 @@ describe('Core', () => {
       expect(Object.getPrototypeOf(core.plugins)).to.be.null;
     });
   });
-
-  describe('register()', () => {
-    it('should call the register() function of each plugin', () => {
-      const registerA = spy();
-      const registerB = spy();
-      const plugins = [
-        { register: registerA },
-        { register: registerB },
-      ];
-
-      core.register(plugins);
-
-      expect(registerA).to.be.calledWith(core.plugins);
-      expect(registerB).to.be.calledWith(core.plugins);
-    });
-
-    it('should call the register() functions of each plugin in order',() => {
-      const registerA = spy();
-      const registerB = spy();
-      const registerC = spy();
-      const plugins = [
-        { register: registerA },
-        { register: registerB },
-        { register: registerC },
-      ];
-
-      core.register(plugins);
-
-      expect(registerA).to.be.calledBefore(registerB);
-      expect(registerB).to.be.calledBefore(registerC);
-    });
-  });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-import { assert as sinonAssert, match, spy, stub } from 'sinon';
+import { expect, sinon, spy, stub } from '../../utils';
 import Core from '../../../src/core';
 import * as CoreUtils from '../../../src/utils/core';
 
@@ -49,7 +48,7 @@ describe('Core', () => {
       Object.assign(core.plugins, { m: 'mm' });
 
       expect(() => core.register(plugins)).to.throw();
-      expect(calculateMissingDependencies).to.be.calledWith(plugins, match(core.plugins));
+      expect(calculateMissingDependencies).to.be.calledWith(plugins, sinon.match(core.plugins));
     });
 
     it('should call the lifecycle events on the plugins in order', () => {
@@ -71,11 +70,11 @@ describe('Core', () => {
 
       core.register(plugins);
 
-      expect(registerPlugins).to.be.calledWith(plugins, match(core.plugins));
-      expect(registerPlugins).to.be.calledWith(plugins, match(core.plugins));
+      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.plugins));
+      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.plugins));
       expect(initPlugins).to.be.calledWith(plugins);
       expect(readyPlugins).to.be.calledWith(plugins);
-      sinonAssert.callOrder(
+      sinon.assert.callOrder(
         registerPlugins,
         initPlugins,
         readyPlugins

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -11,8 +11,8 @@ describe('Core', () => {
 
   describe('constructor()', () => {
     it('should create an empty null-prototype plugins registry object', () => {
-      expect(core.plugins).to.be.empty;
-      expect(Object.getPrototypeOf(core.plugins)).to.be.null;
+      expect(core.registry).to.be.empty;
+      expect(Object.getPrototypeOf(core.registry)).to.be.null;
     });
   });
 
@@ -45,10 +45,10 @@ describe('Core', () => {
         },
       ];
       calculateMissingDependencies.returns(['x']);
-      Object.assign(core.plugins, { m: 'mm' });
+      Object.assign(core.registry, { m: 'mm' });
 
       expect(() => core.register(plugins)).to.throw();
-      expect(calculateMissingDependencies).to.be.calledWith(plugins, sinon.match(core.plugins));
+      expect(calculateMissingDependencies).to.be.calledWith(plugins, sinon.match(core.registry));
     });
 
     it('should call the lifecycle events on the plugins in order', () => {
@@ -70,8 +70,8 @@ describe('Core', () => {
 
       core.register(plugins);
 
-      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.plugins));
-      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.plugins));
+      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.registry));
+      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.registry));
       expect(initPlugins).to.be.calledWith(plugins);
       expect(readyPlugins).to.be.calledWith(plugins);
       sinon.assert.callOrder(

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -51,7 +51,7 @@ describe('Core', () => {
       expect(calculateMissingDependencies).to.be.calledWith(plugins, sinon.match(core.registry));
     });
 
-    it('should call the lifecycle events on the plugins in order', () => {
+    it('should call the lifecycle events in order on the plugins', () => {
       const plugins: any = [
         {
           metadata: {

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { match, spy, stub } from 'sinon';
 import Core from '../../../src/core';
+import * as CoreUtils from '../../../src/utils/core';
 
 describe('Core', () => {
   let core: Core;
@@ -16,9 +17,27 @@ describe('Core', () => {
     });
   });
 
-  // describe('register()', () => {
-  //   it('should throw if dependencies are not met', () => {
+  describe('register()', () => {
+    it('should throw if dependencies are not met', () => {
+      const plugins: any = [
+        {
+          metadata: {
+            name: 'a',
+            depends: ['x'],
+          },
+        },
+        {
+          metadata: {
+            name: 'b',
+            depends: ['a'],
+          },
+        },
+      ];
+      const calculateMissingDependencies = stub(CoreUtils, 'calculateMissingDependencies').returns(['x']);
+      Object.assign(core.plugins, { m: 'mm' });
 
-  //   });
-  // })
+      expect(() => core.register(plugins)).to.throw();
+      expect(calculateMissingDependencies).to.be.calledWith(plugins, match(core.plugins));
+    });
+  });
 });

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../src';
 import Core from '../../../src/core';
 import { Plugin, PluginMetadata, PluginRegistry } from '../../../src/plugin';
-import * as CoreUtils from '../../../src/utils/core';
 
 describe('Entry point', () => {
   it('should export Core', () => {

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../utils';
 import {
   Core as CoreExport,
   Plugin as PluginExport,

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import CoreExport, { Plugin as PluginExport, PluginMetadata as PluginMetadataExport } from '../../../src';
+import Core from '../../../src/core';
+import { Plugin, PluginMetadata } from '../../../src/plugin';
+import * as CoreUtils from '../../../src/utils/core';
+
+describe('Entry point', () => {
+  it('should export Core as default', () => {
+    expect(CoreExport).to.equal(Core);
+  });
+
+  it('should export the Plugin interface', () => {
+    // The following should cause a compiler error if the two interfaces are not equal.
+    const plugin_is_assignable_to_plugin_export: PluginExport = {} as Plugin;
+    const plugin_export_is_assignable_to_plugin: Plugin = {} as PluginExport;
+  });
+
+  it('should export the PluginMetadata interface', () => {
+    // The following should cause a compiler error if the two interfaces are not equal.
+    const plugin_metadata_is_assignable_to_plugin_metadata_export: PluginMetadataExport = {} as PluginMetadata;
+    const plugin_metadata_export_is_assignable_to_plugin_metadata: PluginMetadata = {} as PluginMetadataExport;
+  });
+});

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
-import CoreExport, { Plugin as PluginExport, PluginMetadata as PluginMetadataExport } from '../../../src';
+import {
+  Core as CoreExport,
+  Plugin as PluginExport,
+  PluginMetadata as PluginMetadataExport,
+  PluginRegistry as PluginRegistryExport,
+} from '../../../src';
 import Core from '../../../src/core';
-import { Plugin, PluginMetadata } from '../../../src/plugin';
+import { Plugin, PluginMetadata, PluginRegistry } from '../../../src/plugin';
 import * as CoreUtils from '../../../src/utils/core';
 
 describe('Entry point', () => {
@@ -19,5 +24,11 @@ describe('Entry point', () => {
     // The following should cause a compiler error if the two interfaces are not equal.
     const plugin_metadata_is_assignable_to_plugin_metadata_export: PluginMetadataExport = {} as PluginMetadata;
     const plugin_metadata_export_is_assignable_to_plugin_metadata: PluginMetadata = {} as PluginMetadataExport;
+  });
+
+  it('should export the PluginRegistry interface', () => {
+    // The following should cause a compiler error if the two interfaces are not equal.
+    const plugin_registry_is_assignable_to_plugin_registry_export: PluginRegistryExport = {} as PluginRegistry;
+    const plugin_registry_export_is_assignable_to_plugin_registry: PluginRegistry = {} as PluginRegistryExport;
   });
 });

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -10,7 +10,7 @@ import { Plugin, PluginMetadata, PluginRegistry } from '../../../src/plugin';
 import * as CoreUtils from '../../../src/utils/core';
 
 describe('Entry point', () => {
-  it('should export Core as default', () => {
+  it('should export Core', () => {
     expect(CoreExport).to.equal(Core);
   });
 

--- a/packages/@sfx/core/test/unit/common/index.test.ts
+++ b/packages/@sfx/core/test/unit/common/index.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '../../utils';
+import { AssertTypesEqual, expect } from '../../utils';
 import {
   Core as CoreExport,
   Plugin as PluginExport,
@@ -14,20 +14,14 @@ describe('Entry point', () => {
   });
 
   it('should export the Plugin interface', () => {
-    // The following should cause a compiler error if the two interfaces are not equal.
-    const plugin_is_assignable_to_plugin_export: PluginExport = {} as Plugin;
-    const plugin_export_is_assignable_to_plugin: Plugin = {} as PluginExport;
+    const test: AssertTypesEqual<Plugin, PluginExport> = true;
   });
 
   it('should export the PluginMetadata interface', () => {
-    // The following should cause a compiler error if the two interfaces are not equal.
-    const plugin_metadata_is_assignable_to_plugin_metadata_export: PluginMetadataExport = {} as PluginMetadata;
-    const plugin_metadata_export_is_assignable_to_plugin_metadata: PluginMetadata = {} as PluginMetadataExport;
+    const test: AssertTypesEqual<PluginMetadata, PluginMetadataExport> = true;
   });
 
   it('should export the PluginRegistry interface', () => {
-    // The following should cause a compiler error if the two interfaces are not equal.
-    const plugin_registry_is_assignable_to_plugin_registry_export: PluginRegistryExport = {} as PluginRegistry;
-    const plugin_registry_export_is_assignable_to_plugin_registry: PluginRegistry = {} as PluginRegistryExport;
+    const test: AssertTypesEqual<PluginRegistry, PluginRegistryExport> = true;
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -11,5 +11,23 @@ describe('CoreUtils', () => {
 
       expect(missing).to.have.members(['d', 'e']);
     });
+
+    it('should return no missing dependencies when all are met', () => {
+      const available = ['a', 'b', 'c'];
+      const required = ['a', 'b'];
+
+      const missing = getMissingDependencies(available, required);
+
+      expect(missing).to.eql([]);
+    });
+
+    it('should return no missing dependencies when there are no dependencies', () => {
+      const available = ['a', 'b', 'c'];
+      const required = [];
+
+      const missing = getMissingDependencies(available, required);
+
+      expect(missing).to.eql([]);
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import { match, spy } from 'sinon';
 import {
-  getMissingDependencies,
+  calculateMissingDependencies,
   initPlugins,
   readyPlugins,
   registerPlugins,
 } from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
-  describe('getMissingDependencies()', () => {
+  describe('calculateMissingDependencies()', () => {
     it('should return missing dependencies', () => {
       const registry = {
         a: 'aa',
@@ -28,7 +28,7 @@ describe('CoreUtils', () => {
         },
       ]
 
-      const missing = getMissingDependencies(plugins, registry);
+      const missing = calculateMissingDependencies(plugins, registry);
 
       expect(missing).to.have.members(['x', 'z']);
     });
@@ -52,7 +52,7 @@ describe('CoreUtils', () => {
         },
       ]
 
-      const missing = getMissingDependencies(plugins, registry);
+      const missing = calculateMissingDependencies(plugins, registry);
 
       expect(missing).to.deep.equal([]);
     });
@@ -76,7 +76,7 @@ describe('CoreUtils', () => {
         },
       ] as any;
 
-      const missing = getMissingDependencies(plugins, registry);
+      const missing = calculateMissingDependencies(plugins, registry);
 
       expect(missing).to.deep.equal([]);
     });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -168,8 +168,8 @@ describe('CoreUtils', () => {
 
     it('should return a map of new plugin keys to exposed values', () => {
       const valueA = { a: 'a' };
-      const valueB = { b: 'b' };
-      const valueC = { c: 'c' };
+      const valueB = () => /b/;
+      const valueC = 'c';
       const plugins: any = [
         {
           metadata: { name: 'pluginA' },

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -18,7 +18,7 @@ describe('CoreUtils', () => {
 
       const missing = getMissingDependencies(available, required);
 
-      expect(missing).to.eql([]);
+      expect(missing).to.deep.equal([]);
     });
 
     it('should return no missing dependencies when there are no dependencies', () => {
@@ -27,7 +27,7 @@ describe('CoreUtils', () => {
 
       const missing = getMissingDependencies(available, required);
 
-      expect(missing).to.eql([]);
+      expect(missing).to.deep.equal([]);
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -5,11 +5,11 @@ describe('CoreUtils', () => {
   describe('getMissingDependencies()', () => {
     it('should return missing dependencies', () => {
       const available = ['a', 'b', 'c'];
-      const required = ['a', 'b', 'd'];
+      const required = ['a', 'd', 'b', 'e'];
 
       const missing = getMissingDependencies(available, required);
 
-      expect(missing).to.eql(['d']);
+      expect(missing).to.have.members(['d', 'e']);
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -18,11 +18,13 @@ describe('CoreUtils', () => {
       const plugins: any = [
         {
           metadata: {
+            name: 'm',
             depends: ['a', 'x'],
           },
         },
         {
           metadata: {
+            name: 'n',
             depends: ['z'],
           },
         },
@@ -42,11 +44,13 @@ describe('CoreUtils', () => {
       const plugins: any = [
         {
           metadata: {
+            name: 'm',
             depends: ['a', 'b'],
           },
         },
         {
           metadata: {
+            name: 'n',
             depends: ['b'],
           },
         },
@@ -66,11 +70,13 @@ describe('CoreUtils', () => {
       const plugins: any = [
         {
           metadata: {
+            name: 'm',
             depends: [],
           },
         },
         {
           metadata: {
+            name: 'n',
             depends: [],
           },
         },

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -63,7 +63,7 @@ describe('CoreUtils', () => {
         b: 'bb',
         c: 'cc',
       };
-      const plugins = [
+      const plugins: any = [
         {
           metadata: {
             depends: [],
@@ -74,7 +74,7 @@ describe('CoreUtils', () => {
             depends: [],
           },
         },
-      ] as any;
+      ];
 
       const missing = calculateMissingDependencies(plugins, registry);
 

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -3,6 +3,7 @@ import { match, spy } from 'sinon';
 import {
   getMissingDependencies,
   initPlugins,
+  readyPlugins,
   registerPlugins,
 } from '../../../../src/utils/core';
 
@@ -149,6 +150,41 @@ describe('CoreUtils', () => {
       ];
 
       expect(() => initPlugins(plugins)).to.not.throw();
+    });
+  });
+
+  describe('readyPlugins()', () => {
+    it('should call the ready function of each plugin', () => {
+      const readyA = spy();
+      const readyB = spy();
+      const plugins: any = [
+        {
+          metadata: { name: 'pluginA' },
+          ready: readyA,
+        },
+        {
+          metadata: { name: 'pluginB' },
+          ready: readyB,
+        },
+      ];
+
+      readyPlugins(plugins);
+
+      expect(readyA).to.be.called;
+      expect(readyB).to.be.called;
+    });
+
+    it('should not throw when a plugin does not have an ready function', () => {
+      const plugins: any = [
+        {
+          metadata: { name: 'pluginA' },
+        },
+        {
+          metadata: { name: 'pluginB' },
+        },
+      ];
+
+      expect(() => readyPlugins(plugins)).to.not.throw();
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -10,28 +10,73 @@ import {
 describe('CoreUtils', () => {
   describe('getMissingDependencies()', () => {
     it('should return missing dependencies', () => {
-      const available = ['a', 'b', 'c'];
-      const required = ['a', 'd', 'b', 'e'];
+      const registry = {
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+      };
+      const plugins: any = [
+        {
+          metadata: {
+            depends: ['a', 'x'],
+          },
+        },
+        {
+          metadata: {
+            depends: ['z'],
+          },
+        },
+      ]
 
-      const missing = getMissingDependencies(available, required);
+      const missing = getMissingDependencies(plugins, registry);
 
-      expect(missing).to.have.members(['d', 'e']);
+      expect(missing).to.have.members(['x', 'z']);
     });
 
     it('should return no missing dependencies when all are met', () => {
-      const available = ['a', 'b', 'c'];
-      const required = ['a', 'b'];
+      const registry = {
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+      }
+      const plugins: any = [
+        {
+          metadata: {
+            depends: ['a', 'b'],
+          },
+        },
+        {
+          metadata: {
+            depends: ['b'],
+          },
+        },
+      ]
 
-      const missing = getMissingDependencies(available, required);
+      const missing = getMissingDependencies(plugins, registry);
 
       expect(missing).to.deep.equal([]);
     });
 
     it('should return no missing dependencies when there are no dependencies', () => {
-      const available = ['a', 'b', 'c'];
-      const required = [];
+      const registry = {
+        a: 'aa',
+        b: 'bb',
+        c: 'cc',
+      };
+      const plugins = [
+        {
+          metadata: {
+            depends: [],
+          },
+        },
+        {
+          metadata: {
+            depends: [],
+          },
+        },
+      ] as any;
 
-      const missing = getMissingDependencies(available, required);
+      const missing = getMissingDependencies(plugins, registry);
 
       expect(missing).to.deep.equal([]);
     });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { checkDependencies } from '../../../../src/utils/core';
+
+describe('CoreUtils', () => {
+  describe('checkDependencies()', () => {
+    it('should be callable', () => {
+      expect(checkDependencies).to.be.a('function');
+    });
+  });
+});

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import { match, spy } from 'sinon';
-import { getMissingDependencies, registerPlugins } from '../../../../src/utils/core';
+import {
+  getMissingDependencies,
+  initPlugins,
+  registerPlugins,
+} from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
   describe('getMissingDependencies()', () => {
@@ -110,6 +114,41 @@ describe('CoreUtils', () => {
       });
       expect(registry.pluginA).to.equal(valueA);
       expect(registry.pluginB).to.equal(valueB);
+    });
+  });
+
+  describe('initPlugins()', () => {
+    it('should call the init function of each plugin', () => {
+      const initA = spy();
+      const initB = spy();
+      const plugins: any = [
+        {
+          metadata: { name: 'pluginA' },
+          init: initA,
+        },
+        {
+          metadata: { name: 'pluginB' },
+          init: initB,
+        },
+      ];
+
+      initPlugins(plugins);
+
+      expect(initA).to.be.called;
+      expect(initB).to.be.called;
+    });
+
+    it('should not throw when a plugin does not have an init function', () => {
+      const plugins: any = [
+        {
+          metadata: { name: 'pluginA' },
+        },
+        {
+          metadata: { name: 'pluginB' },
+        },
+      ];
+
+      expect(() => initPlugins(plugins)).to.not.throw();
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -110,6 +110,34 @@ describe('CoreUtils', () => {
 
       expect(missing).to.deep.equal([]);
     });
+
+    it('should return no missing dependencies for satisfied circular dependencies', () => {
+      const registry = {};
+      const plugins: any = [
+        {
+          metadata: {
+            name: 'a',
+            depends: ['b'],
+          },
+        },
+        {
+          metadata: {
+            name: 'b',
+            depends: ['c'],
+          },
+        },
+        {
+          metadata: {
+            name: 'c',
+            depends: ['a'],
+          },
+        },
+      ];
+
+      const missing = calculateMissingDependencies(plugins, registry);
+
+      expect(missing).to.deep.equal([]);
+    });
   });
 
   describe('registerPlugins()', () => {

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -80,6 +80,30 @@ describe('CoreUtils', () => {
 
       expect(missing).to.deep.equal([]);
     });
+
+    it('should return no missing dependencies when dependencies are satisfied by the new plugins', () => {
+      const registry = {
+        c: 'cc',
+      };
+      const plugins: any = [
+        {
+          metadata: {
+            name: 'a',
+            depends: ['b', 'c'],
+          },
+        },
+        {
+          metadata: {
+            name: 'b',
+            depends: ['c'],
+          },
+        },
+      ];
+
+      const missing = calculateMissingDependencies(plugins, registry);
+
+      expect(missing).to.deep.equal([]);
+    });
   });
 
   describe('registerPlugins()', () => {

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-import { match, spy } from 'sinon';
+import { expect, spy } from '../../../utils';
 import {
   calculateMissingDependencies,
   initPlugins,

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -3,8 +3,11 @@ import { checkDependencies } from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
   describe('checkDependencies()', () => {
-    it('should be callable', () => {
-      expect(checkDependencies).to.be.a('function');
+    it('should raise an error if there are missing dependencies', () => {
+      const available = ['a', 'b', 'c'];
+      const required = ['a', 'b', 'd'];
+
+      expect(() => checkDependencies(available, required)).to.throw();
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
-import { checkDependencies } from '../../../../src/utils/core';
+import { getMissingDependencies } from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
-  describe('checkDependencies()', () => {
-    it('should raise an error if there are missing dependencies', () => {
+  describe('getMissingDependencies()', () => {
+    it('should return missing dependencies', () => {
       const available = ['a', 'b', 'c'];
       const required = ['a', 'b', 'd'];
 
-      expect(() => checkDependencies(available, required)).to.throw();
+      const missing = getMissingDependencies(available, required);
+
+      expect(missing).to.eql(['d']);
     });
   });
 });

--- a/packages/@sfx/core/test/utils.ts
+++ b/packages/@sfx/core/test/utils.ts
@@ -1,0 +1,1 @@
+export * from '../../../../test/utils';

--- a/packages/@sfx/core/tsconfig.esnext.json
+++ b/packages/@sfx/core/tsconfig.esnext.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node"
+    ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es2015",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "esnext",
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "allowJs": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/@sfx/core/tsconfig.esnext.json
+++ b/packages/@sfx/core/tsconfig.esnext.json
@@ -18,7 +18,7 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
-    "allowJs": true
+    "declaration": true
   },
   "exclude": [
     "node_modules",

--- a/packages/@sfx/core/tsconfig.json
+++ b/packages/@sfx/core/tsconfig.json
@@ -16,7 +16,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "declaration": true
   },
   "exclude": [
     "node_modules",

--- a/packages/@sfx/core/tsconfig.json
+++ b/packages/@sfx/core/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node",
+      "mocha"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/presets/core.ts
+++ b/presets/core.ts
@@ -1,0 +1,1 @@
+import '@sfx/core';

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,3 +8,7 @@ export const chai = global.chai || chaiImport;
 export const expect = chai.expect;
 export const stub = sinon.stub;
 export const spy = sinon.spy;
+
+// Interface S is the same as interface T if and only if they are assignable to each other.
+// This type resolves to the literal type `true` if S = T and `false` if S != T.
+export type AssertTypesEqual<S, T> = S extends T ? T extends S ? true : false : false;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   mode: 'development',
 
   entry: {
+    core: path.resolve(__dirname, 'presets/core.ts'),
     plugins: path.resolve(__dirname, 'presets/plugins.ts'),
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,6 +4674,11 @@ sinon-chai@^3.3.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
   integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
 
+sinon-chai@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
+  integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
+
 sinon@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,11 +4674,6 @@ sinon-chai@^3.3.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
   integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
 
-sinon-chai@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
-  integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==
-
 sinon@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"


### PR DESCRIPTION
Core is the backbone of the entire SF-X system. It manages plugins and allows them to communicate with each other. The core package defines interfaces for plugins.

A registration mechanism is currently implemented. Unregistration will be added separately.