### PR TITLE
SFX-99: Implement blanket unregistration in Core

### DIFF
--- a/packages/@sfx/core/CHANGELOG.md
+++ b/packages/@sfx/core/CHANGELOG.md
@@ -8,4 +8,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SFX-99: Added the `Core` module and related plugin interfaces.
   - The Core module manages the registration and unregistration of plugins.
+    Unregistration of individual plugins is not currently supported.
   - The package also exports the `Plugin`, `PluginMetadata`, and `PluginRegistry` interfaces.

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -72,5 +72,7 @@ export default class Core {
     const plugins = pluginNames.map((name) => this.plugins[name]);
 
     unregisterPlugins(plugins, this.registry);
+
+    pluginNames.forEach((p) => delete this.plugins[p]);
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -26,7 +26,7 @@ export default class Core {
   /**
    * TODO
    */
-  plugins: PluginDirectory = Object.create(null);
+  directory: PluginDirectory = Object.create(null);
 
   /**
    * Register one or more plugins with Core.
@@ -59,7 +59,7 @@ export default class Core {
       throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
     }
 
-    registerPlugins(plugins, this.registry, this.plugins);
+    registerPlugins(plugins, this.registry, this.directory);
 
     initPlugins(plugins);
     readyPlugins(plugins);
@@ -69,6 +69,6 @@ export default class Core {
    * TODO
    */
   unregisterAll() {
-    unregisterPlugins(Object.keys(this.plugins), this.registry, this.plugins);
+    unregisterPlugins(Object.keys(this.directory), this.registry, this.directory);
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -59,11 +59,7 @@ export default class Core {
       throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
     }
 
-    plugins.forEach((plugin) => {
-      this.plugins[plugin.metadata.name] = plugin;
-    });
-
-    registerPlugins(plugins, this.registry);
+    registerPlugins(plugins, this.registry, this.plugins);
 
     initPlugins(plugins);
     readyPlugins(plugins);
@@ -73,11 +69,6 @@ export default class Core {
    * TODO
    */
   unregisterAll() {
-    const pluginNames = Object.keys(this.plugins);
-    const plugins = pluginNames.map((name) => this.plugins[name]);
-
-    unregisterPlugins(plugins, this.registry);
-
-    pluginNames.forEach((p) => delete this.plugins[p]);
+    unregisterPlugins(Object.keys(this.plugins), this.registry, this.plugins);
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -1,9 +1,10 @@
-import { Plugin, PluginRegistry } from './plugin';
+import { Plugin, PluginDirectory, PluginRegistry } from './plugin';
 import {
   calculateMissingDependencies,
   initPlugins,
   readyPlugins,
   registerPlugins,
+  unregisterPlugins,
 } from './utils/core';
 
 /**
@@ -21,6 +22,11 @@ export default class Core {
    * plugin is discouraged.
    */
   registry: PluginRegistry = Object.create(null);
+
+  /**
+   * TODO
+   */
+  plugins: PluginDirectory = Object.create(null);
 
   /**
    * Register one or more plugins with Core.
@@ -56,5 +62,15 @@ export default class Core {
     registerPlugins(plugins, this.registry);
     initPlugins(plugins);
     readyPlugins(plugins);
+  }
+
+  /**
+   * TODO
+   */
+  unregisterAll() {
+    const pluginNames = Object.keys(this.plugins);
+    const plugins = pluginNames.map((name) => this.plugins[name]);
+
+    unregisterPlugins(plugins, this.registry);
   }
 }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -24,7 +24,10 @@ export default class Core {
   registry: PluginRegistry = Object.create(null);
 
   /**
-   * TODO
+   * The plugin directory. This object is a dictionary containing plugin
+   * names as keys and the plugin object as values.
+   *
+   * Plugins do not have access to this directory.
    */
   directory: PluginDirectory = Object.create(null);
 
@@ -66,7 +69,10 @@ export default class Core {
   }
 
   /**
-   * TODO
+   * Unregisters all plugins. The plugin registry and directory are both
+   * cleared. The optional `unregister` function of each plugin is
+   * called when the plugin is unregistered. The order in which the
+   * plugins are unregistered is unspecified.
    */
   unregisterAll() {
     unregisterPlugins(Object.keys(this.directory), this.registry, this.directory);

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -25,7 +25,7 @@ export default class Core {
 
   /**
    * The plugin directory. This object is a dictionary containing plugin
-   * names as keys and the plugin object as values.
+   * names as keys and the plugin objects as values.
    *
    * Plugins do not have access to this directory.
    */

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -60,6 +60,11 @@ export default class Core {
     }
 
     registerPlugins(plugins, this.registry);
+
+    plugins.forEach((plugin) => {
+      this.plugins[plugin.metadata.name] = plugin;
+    });
+
     initPlugins(plugins);
     readyPlugins(plugins);
   }

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -59,11 +59,11 @@ export default class Core {
       throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
     }
 
-    registerPlugins(plugins, this.registry);
-
     plugins.forEach((plugin) => {
       this.plugins[plugin.metadata.name] = plugin;
     });
+
+    registerPlugins(plugins, this.registry);
 
     initPlugins(plugins);
     readyPlugins(plugins);

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -52,7 +52,13 @@ export interface Plugin {
    */
   ready?: () => void;
 
-  /** TODO */
+  /**
+   * The callback for the unregistration phase of the lifecycle. The
+   * plugin is expected to perform teardown tasks in this function.
+   *
+   * In this function, the plugin can assume that other plugins are
+   * still available to be used.
+   */
   unregister?: () => void;
 }
 

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -51,6 +51,9 @@ export interface Plugin {
    * been initialized and may safely use other plugins.
    */
   ready?: () => void;
+
+  /** TODO */
+  unregister?: () => void;
 }
 
 /**

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -84,3 +84,11 @@ export interface PluginMetadata {
 export interface PluginRegistry {
   [key: string]: any;
 }
+
+
+/**
+ * The type of the plugin directory, which holds plugins keyed by name.
+ */
+export interface PluginDirectory {
+  [name: string]: Plugin;
+}

--- a/packages/@sfx/core/src/plugin.ts
+++ b/packages/@sfx/core/src/plugin.ts
@@ -57,7 +57,7 @@ export interface Plugin {
    * plugin is expected to perform teardown tasks in this function.
    *
    * In this function, the plugin can assume that other plugins are
-   * still available to be used.
+   * still available for use.
    */
   unregister?: () => void;
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -81,5 +81,7 @@ export function unregisterPlugins(plugins: Plugin[], registry: PluginRegistry) {
     if (typeof plugin.unregister === 'function') {
       plugin.unregister();
     }
+
+    delete registry[plugin.metadata.name];
   });
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -72,3 +72,12 @@ export function readyPlugins(plugins: Plugin[]) {
     }
   });
 }
+
+/**
+ * TODO
+ */
+export function unregisterAllPlugins(plugins: Plugin[], registry: PluginRegistry) {
+  plugins.forEach((plugin) => {
+    plugin.unregister();
+  });
+}

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -78,6 +78,8 @@ export function readyPlugins(plugins: Plugin[]) {
  */
 export function unregisterAllPlugins(plugins: Plugin[], registry: PluginRegistry) {
   plugins.forEach((plugin) => {
-    plugin.unregister();
+    if (typeof plugin.unregister === 'function') {
+      plugin.unregister();
+    }
   });
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -92,7 +92,8 @@ export function unregisterPlugins(names: string[], registry: PluginRegistry, dir
     if (typeof plugin.unregister === 'function') {
       plugin.unregister();
     }
-
+  });
+  names.forEach((name) => {
     delete registry[name];
     delete directory[name];
   });

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginRegistry } from '../plugin';
+import { Plugin, PluginDirectory, PluginRegistry } from '../plugin';
 
 /**
  * Calculates the missing dependencies of the given plugins. The given
@@ -29,21 +29,25 @@ export function calculateMissingDependencies(plugins: Plugin[], registry: Plugin
  * each plugin are added to the given registry.
  *
  * @param plugins The plugins to register.
- * @param registry The registry into which to add the plugins.
+ * @param registry The registry into which to add the plugins' exposed values.
+ * @param directory The directory into which to add the plugins.
  * @returns An object containing the keys and values of the new items
  * added to the registry.
  */
-export function registerPlugins(plugins: Plugin[], registry: PluginRegistry): PluginRegistry {
+export function registerPlugins(plugins: Plugin[], registry: PluginRegistry, directory: PluginDirectory): PluginRegistry {
   const newlyRegistered = Object.create(null);
+  const newPlugins = Object.create(null);
 
   plugins.forEach((plugin) => {
     const exposedValue = plugin.register(Object.create(registry));
     const { name } = plugin.metadata;
 
     newlyRegistered[name] = exposedValue;
+    newPlugins[name] = plugin;
   });
 
   Object.assign(registry, newlyRegistered);
+  Object.assign(directory, newPlugins);
   return newlyRegistered;
 }
 
@@ -74,14 +78,16 @@ export function readyPlugins(plugins: Plugin[]) {
 }
 
 /**
- * TODO
+ * 
  */
-export function unregisterPlugins(plugins: Plugin[], registry: PluginRegistry) {
-  plugins.forEach((plugin) => {
+export function unregisterPlugins(names: string[], registry: PluginRegistry, directory: PluginDirectory) {
+  names.forEach((name) => {
+    const plugin = directory[name];
     if (typeof plugin.unregister === 'function') {
       plugin.unregister();
     }
 
-    delete registry[plugin.metadata.name];
+    delete registry[name];
+    delete directory[name];
   });
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -76,7 +76,7 @@ export function readyPlugins(plugins: Plugin[]) {
 /**
  * TODO
  */
-export function unregisterAllPlugins(plugins: Plugin[], registry: PluginRegistry) {
+export function unregisterPlugins(plugins: Plugin[], registry: PluginRegistry) {
   plugins.forEach((plugin) => {
     if (typeof plugin.unregister === 'function') {
       plugin.unregister();

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -78,7 +78,13 @@ export function readyPlugins(plugins: Plugin[]) {
 }
 
 /**
- * 
+ * Unregisters the plugins with the given names from the given registry
+ * and directory.
+ *
+ * @param names The names of the plugins to unregister.
+ * @param registry The registry from which to unregister the plugin's
+ * exposed value.
+ * @param directory The directory from which to unregister the plugin.
  */
 export function unregisterPlugins(names: string[], registry: PluginRegistry, directory: PluginDirectory) {
   names.forEach((name) => {

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -80,4 +80,45 @@ describe('Core', () => {
       );
     });
   });
+
+  describe('unregisterAll()', () => {
+    it('should call unregisterPlugins with all plugins', () => {
+      const pluginA: any = {
+        metadata: {
+          name: 'a',
+          depends: [],
+        },
+      };
+      const pluginB: any = {
+        metadata: {
+          name: 'b',
+          depends: ['a'],
+        },
+      };
+      const pluginC: any = {
+        metadata: {
+          name: 'c',
+          depends: ['a'],
+        },
+      };
+      const plugins = core.plugins = {
+        a: pluginA,
+        b: pluginB,
+        c: pluginC,
+      };
+      const registry = core.registry = {
+        a: { a: 'a' },
+        b: () => /b/,
+        c: 'c',
+      };
+      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
+      const pluginArrayMatcher =
+        sinon.match.array.contains([pluginA, pluginB, pluginC])
+        .and(sinon.match((arr) => arr.length === 3));
+
+      core.unregisterAll();
+
+      expect(unregisterPlugins).to.be.calledWith(pluginArrayMatcher, sinon.match.same(registry));
+    });
+  });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -120,5 +120,36 @@ describe('Core', () => {
 
       expect(unregisterPlugins).to.be.calledWith(pluginArrayMatcher, sinon.match.same(registry));
     });
+
+    it('should clear the plugin directory', () => {
+      const pluginA: any = {
+        metadata: {
+          name: 'a',
+          depends: [],
+        },
+      };
+      const pluginB: any = {
+        metadata: {
+          name: 'b',
+          depends: ['a'],
+        },
+      };
+      const pluginC: any = {
+        metadata: {
+          name: 'c',
+          depends: ['a'],
+        },
+      };
+      const plugins = core.plugins = {
+        a: pluginA,
+        b: pluginB,
+        c: pluginC,
+      };
+      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
+
+      core.unregisterAll();
+
+      expect(plugins).to.deep.equal({});
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -79,6 +79,41 @@ describe('Core', () => {
         readyPlugins
       );
     });
+
+    it('should add the plugins to the plugin directory', () => {
+      const pluginA: any = {
+        metadata: {
+          name: 'a',
+          depends: [],
+        },
+      };
+      const pluginB: any = {
+        metadata: {
+          name: 'b',
+          depends: [],
+        },
+      };
+      const pluginC: any = {
+        metadata: {
+          name: 'c',
+          depends: [],
+        },
+      };
+      const plugins: any = [pluginA, pluginB];
+      core.plugins = { c: pluginC };
+      calculateMissingDependencies.returns([]);
+
+      core.register(plugins);
+
+      expect(core.plugins).to.deep.equal({
+        a: pluginA,
+        b: pluginB,
+        c: pluginC,
+      });
+      expect(core.plugins.a).to.equal(pluginA);
+      expect(core.plugins.b).to.equal(pluginB);
+      expect(core.plugins.c).to.equal(pluginC);
+    });
   });
 
   describe('unregisterAll()', () => {

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -16,8 +16,8 @@ describe('Core', () => {
     });
 
     it('should create an empty null-prototype plugins directory object', () => {
-      expect(core.plugins).to.be.empty;
-      expect(Object.getPrototypeOf(core.plugins)).to.be.null;
+      expect(core.directory).to.be.empty;
+      expect(Object.getPrototypeOf(core.directory)).to.be.null;
     });
   });
 
@@ -78,7 +78,7 @@ describe('Core', () => {
       expect(registerPlugins).to.be.calledWith(
         plugins,
         sinon.match(core.registry),
-        sinon.match(core.plugins)
+        sinon.match(core.directory)
       );
       expect(initPlugins).to.be.calledWith(plugins);
       expect(readyPlugins).to.be.calledWith(plugins);
@@ -98,7 +98,7 @@ describe('Core', () => {
         b: () => /b/,
         c: 'c',
       };
-      const directory = core.plugins = {
+      const directory = core.directory = {
         a: { metadata: { name: 'a', depends: [] } },
         b: { metadata: { name: 'b', depends: ['a'] } },
         c: { metadata: { name: 'c', depends: ['a'] } },

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -75,7 +75,11 @@ describe('Core', () => {
 
       core.register(plugins);
 
-      expect(registerPlugins).to.be.calledWith(plugins, sinon.match(core.registry));
+      expect(registerPlugins).to.be.calledWith(
+        plugins,
+        sinon.match(core.registry),
+        sinon.match(core.plugins)
+      );
       expect(initPlugins).to.be.calledWith(plugins);
       expect(readyPlugins).to.be.calledWith(plugins);
       sinon.assert.callOrder(
@@ -84,112 +88,30 @@ describe('Core', () => {
         readyPlugins
       );
     });
-
-    it('should add the plugins to the plugin directory', () => {
-      const pluginA: any = {
-        metadata: {
-          name: 'a',
-          depends: [],
-        },
-      };
-      const pluginB: any = {
-        metadata: {
-          name: 'b',
-          depends: [],
-        },
-      };
-      const pluginC: any = {
-        metadata: {
-          name: 'c',
-          depends: [],
-        },
-      };
-      const plugins: any = [pluginA, pluginB];
-      core.plugins = { c: pluginC };
-      calculateMissingDependencies.returns([]);
-
-      core.register(plugins);
-
-      expect(core.plugins).to.deep.equal({
-        a: pluginA,
-        b: pluginB,
-        c: pluginC,
-      });
-      expect(core.plugins.a).to.equal(pluginA);
-      expect(core.plugins.b).to.equal(pluginB);
-      expect(core.plugins.c).to.equal(pluginC);
-    });
   });
 
   describe('unregisterAll()', () => {
     it('should call unregisterPlugins with all plugins', () => {
-      const pluginA: any = {
-        metadata: {
-          name: 'a',
-          depends: [],
-        },
-      };
-      const pluginB: any = {
-        metadata: {
-          name: 'b',
-          depends: ['a'],
-        },
-      };
-      const pluginC: any = {
-        metadata: {
-          name: 'c',
-          depends: ['a'],
-        },
-      };
-      const plugins = core.plugins = {
-        a: pluginA,
-        b: pluginB,
-        c: pluginC,
-      };
+      const names = ['a', 'b', 'c'];
       const registry = core.registry = {
         a: { a: 'a' },
         b: () => /b/,
         c: 'c',
       };
-      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
-      const pluginArrayMatcher =
-        sinon.match.array.contains([pluginA, pluginB, pluginC])
-        .and(sinon.match((arr) => arr.length === 3));
-
-      core.unregisterAll();
-
-      expect(unregisterPlugins).to.be.calledWith(pluginArrayMatcher, sinon.match.same(registry));
-    });
-
-    it('should clear the plugin directory', () => {
-      const pluginA: any = {
-        metadata: {
-          name: 'a',
-          depends: [],
-        },
-      };
-      const pluginB: any = {
-        metadata: {
-          name: 'b',
-          depends: ['a'],
-        },
-      };
-      const pluginC: any = {
-        metadata: {
-          name: 'c',
-          depends: ['a'],
-        },
-      };
-      const plugins = core.plugins = {
-        a: pluginA,
-        b: pluginB,
-        c: pluginC,
-      };
+      const directory = core.plugins = {
+        a: { metadata: { name: 'a', depends: [] } },
+        b: { metadata: { name: 'b', depends: ['a'] } },
+        c: { metadata: { name: 'c', depends: ['a'] } },
+      } as any;
       const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
 
       core.unregisterAll();
 
-      expect(plugins).to.deep.equal({});
+      expect(unregisterPlugins).to.be.calledWith(
+        names,
+        sinon.match.same(registry),
+        sinon.match.same(directory)
+      );
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -14,6 +14,11 @@ describe('Core', () => {
       expect(core.registry).to.be.empty;
       expect(Object.getPrototypeOf(core.registry)).to.be.null;
     });
+
+    it('should create an empty null-prototype plugins directory object', () => {
+      expect(core.plugins).to.be.empty;
+      expect(Object.getPrototypeOf(core.plugins)).to.be.null;
+    });
   });
 
   describe('register()', () => {

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -399,6 +399,31 @@ describe('CoreUtils', () => {
       expect(registry).to.deep.equal({ b: bValue });
     });
 
+    it('should not remove the entry from the registry until all the unregistration hooks have been called', () => {
+      const valueA = spy();
+      const valueB = spy();
+      const names = ['a', 'b'];
+      const registry = {
+        a: valueA,
+        b: valueB,
+      };
+      const directory: any = {
+        a: {
+          metadata: { name: 'a' },
+          unregister: () => registry.b(),
+        },
+        b: {
+          metadata: { name: 'b' },
+          unregister: () => registry.a(),
+        },
+      };
+
+      unregisterPlugins(names, registry, directory);
+
+      expect(valueA).to.be.called;
+      expect(valueB).to.be.called;
+    });
+
     it('should remove the corresponding entry from the directory', () => {
       const names = ['a', 'c'];
       const pluginB = {

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -346,6 +346,29 @@ describe('CoreUtils', () => {
       expect(unregisterC).to.be.called;
     });
 
+    it('should remove the corresponding entry from the registry', () => {
+      const bValue = () => /b/;
+      const plugins: any = [
+        {
+          metadata: { name: 'a' },
+          unregister: () => null,
+        },
+        {
+          metadata: { name: 'c' },
+          unregister: () => null,
+        },
+      ];
+      const registry: any = {
+        a: { a: 'a' },
+        b: bValue,
+        c: 'c',
+      };
+
+      unregisterPlugins(plugins, registry);
+
+      expect(registry).to.deep.equal({ b: bValue });
+    });
+
     it('should not throw when a plugin does not have an unregister function', () => {
       const plugins: any = [
         {

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -4,7 +4,7 @@ import {
   initPlugins,
   readyPlugins,
   registerPlugins,
-  unregisterAllPlugins,
+  unregisterPlugins,
 } from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
@@ -314,7 +314,7 @@ describe('CoreUtils', () => {
     });
   });
 
-  describe('unregisterAllPlugins()', () => {
+  describe('unregisterPlugins()', () => {
     it('should call the unregister function of all plugins', () => {
       const unregisterA = spy();
       const unregisterB = spy();
@@ -339,7 +339,7 @@ describe('CoreUtils', () => {
         c: 'c',
       };
 
-      unregisterAllPlugins(plugins, registry);
+      unregisterPlugins(plugins, registry);
 
       expect(unregisterA).to.be.called;
       expect(unregisterB).to.be.called;
@@ -366,7 +366,7 @@ describe('CoreUtils', () => {
         c: 'c',
       };
 
-      expect(() => unregisterAllPlugins(plugins, registry)).to.not.throw();
+      expect(() => unregisterPlugins(plugins, registry)).to.not.throw();
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -4,6 +4,7 @@ import {
   initPlugins,
   readyPlugins,
   registerPlugins,
+  unregisterAllPlugins,
 } from '../../../../src/utils/core';
 
 describe('CoreUtils', () => {
@@ -314,7 +315,37 @@ describe('CoreUtils', () => {
   });
 
   describe('unregisterAllPlugins()', () => {
-    it('should call the unregister function of all plugins');
+    it('should call the unregister function of all plugins', () => {
+      const unregisterA = spy();
+      const unregisterB = spy();
+      const unregisterC = spy();
+      const plugins: any = [
+        {
+          metadata: { name: 'a' },
+          unregister: unregisterA,
+        },
+        {
+          metadata: { name: 'b' },
+          unregister: unregisterB,
+        },
+        {
+          metadata: { name: 'c' },
+          unregister: unregisterC,
+        },
+      ];
+      const registry: any = {
+        a: { a: 'a' },
+        b: () => /b/,
+        c: 'c',
+      };
+
+      unregisterAllPlugins(plugins, registry);
+
+      expect(unregisterA).to.be.called;
+      expect(unregisterB).to.be.called;
+      expect(unregisterC).to.be.called;
+    });
+
     it('should clear the registry');
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -346,6 +346,27 @@ describe('CoreUtils', () => {
       expect(unregisterC).to.be.called;
     });
 
-    it('should clear the registry');
+    it('should not throw when a plugin does not have an unregister function', () => {
+      const plugins: any = [
+        {
+          metadata: { name: 'a' },
+          unregister: () => null,
+        },
+        {
+          metadata: { name: 'b' },
+        },
+        {
+          metadata: { name: 'c' },
+          unregister: () => null,
+        },
+      ];
+      const registry: any = {
+        a: { a: 'a' },
+        b: () => /b/,
+        c: 'c',
+      };
+
+      expect(() => unregisterAllPlugins(plugins, registry)).to.not.throw();
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -312,4 +312,9 @@ describe('CoreUtils', () => {
       expect(() => readyPlugins(plugins)).to.not.throw();
     });
   });
+
+  describe('unregisterAllPlugins()', () => {
+    it('should call the unregister function of all plugins');
+    it('should clear the registry');
+  });
 });


### PR DESCRIPTION
Core now implements an `unregisterAll` function that will unregister all plugins. Unregistering one or more plugins without unregistering all of them is not yet supported.

Also added is an `unregister` hook to the plugin interface that is called when the plugin is being unregistered.