### PR TITLE
Specify module entry point for webpack within packages

### DIFF
--- a/packages/@sfx/core/package.json
+++ b/packages/@sfx/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "SF-X Core",
   "main": "dist/index.js",
+  "module": "src/index.ts",
   "types": "dist/index.d.ts",
   "esnext": "esnext/index.js",
   "scripts": {

--- a/packages/@sfx/dom-events-plugin/package.json
+++ b/packages/@sfx/dom-events-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/index.js",
+  "module": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../../scripts/build.sh",

--- a/packages/@sfx/sayt-plugin/package.json
+++ b/packages/@sfx/sayt-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/index.js",
+  "module": "src/index.ts",
   "scripts": {
     "build": "../../../scripts/build.sh",
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",


### PR DESCRIPTION
This change is required to allow webpack to easily bundle all of our packages together; while enabling us to dictate what gets published for each package to npm separately.