### PR TITLE
Avoid conflict in interface names

### DIFF
--- a/packages/@sfx/sayt-driver-plugin/src/index.ts
+++ b/packages/@sfx/sayt-driver-plugin/src/index.ts
@@ -1,6 +1,6 @@
 export {
   default as SaytDriverPlugin,
-  AutocompleteConfig,
+  AutocompleteRequestConfig,
   AutocompleteResponseSection,
   SearchTermItem,
 } from './sayt-driver-plugin';

--- a/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
+++ b/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
@@ -96,7 +96,7 @@ export default class SaytDriverPlugin implements Plugin {
    * @returns A promise from the Sayt API that has been reformatted
    * with the passed callback.
    */
-  sendSaytApiRequest({ query, ...config }: AutocompleteConfig): Promise<string[]> {
+  sendSaytApiRequest({ query, ...config }: AutocompleteRequestConfig): Promise<string[]> {
     return this.core.sayt.autocomplete(query, config).then(this.autocompleteCallback);
   }
 
@@ -133,7 +133,7 @@ export default class SaytDriverPlugin implements Plugin {
 /**
  * The type of the sayt autocomplete request event payload.
  */
-export interface AutocompleteConfig extends QueryTimeAutocompleteConfig {
+export interface AutocompleteRequestConfig extends QueryTimeAutocompleteConfig {
   query: string;
 }
 /**

--- a/packages/@sfx/sayt-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@sfx/sayt-driver-plugin/test/unit/common/index.test.ts
@@ -1,13 +1,13 @@
 import { AssertTypesEqual, expect } from '../../utils';
 import {
-  AutocompleteConfig as AutocompleteConfigExport,
+  AutocompleteRequestConfig as AutocompleteRequestConfigExport,
   AutocompleteResponseSection as AutocompleteResponseSectionExport,
   SaytDriverPlugin as SaytDriverPluginExport,
   SearchTermItem as SearchTermItemExport,
 } from '../../../src';
 import {
   default as SaytDriverPlugin,
-  AutocompleteConfig,
+  AutocompleteRequestConfig,
   AutocompleteResponseSection,
   SearchTermItem,
 } from '../../../src/sayt-driver-plugin';
@@ -18,8 +18,8 @@ describe('Entry point', () => {
     expect(SaytDriverPluginExport).to.equal(SaytDriverPlugin);
   });
 
-  it('should export the AutocompleteConfig interface', () => {
-    const test: AssertTypesEqual<AutocompleteConfigExport, AutocompleteConfig> = true;
+  it('should export the AutocompleteRequestConfig interface', () => {
+    const test: AssertTypesEqual<AutocompleteRequestConfigExport, AutocompleteRequestConfig> = true;
   });
 
   it('should export the AutocompleteResponseSection interface', () => {


### PR DESCRIPTION
AutocompleteConfig was already being exported from the Sayt Client.