### PR TITLE
SFX-159: Add Search Driver plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ jobs:
       - restore_cache:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_sayt_driver_plugin-
       - run: *extract_build_archive
+      - restore_cache:
+          key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_search_driver_plugin-
+      - run: *extract_build_archive
       - run: *archive_build
       - save_cache:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-all-{{ epoch }}
@@ -197,10 +200,15 @@ workflows:
           name: build_sayt_driver_plugin
           requires:
             - collect_independent_builds
+      - build:
+          name: build_search_driver_plugin
+          requires:
+            - collect_independent_builds
       - collect_builds:
           name: build_final
           requires:
             - build_sayt_driver_plugin
+            - build_search_driver_plugin
 
       - unit_test:
           name: unit_test_core
@@ -216,6 +224,9 @@ workflows:
           <<: *requires_build_final
       - unit_test:
           name: unit_test_sayt_driver_plugin
+          <<: *requires_build_final
+      - unit_test:
+          name: unit_test_search_driver_plugin
           <<: *requires_build_final
 
       - unit_test_browser:
@@ -233,6 +244,9 @@ workflows:
       - unit_test_browser:
           name: unit_test_browser_sayt_driver_plugin
           <<: *requires_build_final
+      - unit_test_browser:
+          name: unit_test_browser_search_driver_plugin
+          <<: *requires_build_final
       - unit_test_final:
           requires:
             - unit_test_core
@@ -240,8 +254,10 @@ workflows:
             - unit_test_sayt_plugin
             - unit_test_search_plugin
             - unit_test_sayt_driver_plugin
+            - unit_test_search_driver_plugin
             - unit_test_browser_core
             - unit_test_browser_dom_events_plugin
             - unit_test_browser_sayt_plugin
             - unit_test_browser_search_plugin
             - unit_test_browser_sayt_driver_plugin
+            - unit_test_browser_search_driver_plugin

--- a/packages/@sfx/search-driver-plugin/CHANGELOG.md
+++ b/packages/@sfx/search-driver-plugin/CHANGELOG.md
@@ -7,4 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - SFX-159: Added the `SearchDriverPlugin` module.
-  - [@TODO FILL THIS IN]
+  - This plugin listens for a `SEARCH_REQUEST_EVENT` event, makes a
+    search request using the GroupBy API, then dispatches a
+    `SEARCH_RESPONSE_EVENT` event containing the response.

--- a/packages/@sfx/search-driver-plugin/CHANGELOG.md
+++ b/packages/@sfx/search-driver-plugin/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- SFX-159: Added the `SearchDriverPlugin` module.
+  - [@TODO FILL THIS IN]

--- a/packages/@sfx/search-driver-plugin/README.md
+++ b/packages/@sfx/search-driver-plugin/README.md
@@ -1,15 +1,41 @@
 # SF-X Search Driver Plugin
 
-This package contains the SF-X Search Driver Plugin class.
+This package contains the SF-X Search Driver plugin.
+
+## Prerequisites
+
+This plugin depends on the following plugins:
+
+- `dom_events`
+- `search`
+
+These plugins must be registered either before or in the same batch as
+this plugin.
 
 ## Usage
-[ @TODO FILL THIS IN]
-<!-- To use the plugin, simply instantiate it and register it with Core:
+
+To use the plugin, simply instantiate it and register it with Core:
 
 ```js
-const saytPlugin = new SaytPlugin(/* options */);
-core.register(saytPlugin);
+const searchPlugin = new SearchPlugin();
+core.register(searchPlugin);
 ```
-The plugin registers an instance of the [Sayt client](https://www.npmjs.com/package/sayt) with Core.
 
-The SaytPlugin constructor can accept options to configure the exposed Sayt client. See the [SaytConfig interface](https://github.com/groupby/sayt-client/blob/develop/src/core/sayt.ts#L77) for available options. -->
+This plugin currently does not accept any options.
+
+## Events
+
+This plugin listens for and dispatches a number of events.
+
+### Received
+
+* `sfx::search_request`: When received, a search request to the GroupBy
+  API is made. An `sfx::search_response` event is dispatched with the
+  results.
+
+### Dispatched
+
+* `sfx::search_response`: Dispatched when a search request has
+  completed. Its payload is the result of the request.
+* `sfx::search_error`: Dispatched when an error has occurred during a
+  search request.

--- a/packages/@sfx/search-driver-plugin/README.md
+++ b/packages/@sfx/search-driver-plugin/README.md
@@ -1,0 +1,15 @@
+# SF-X Search Driver Plugin
+
+This package contains the SF-X Search Driver Plugin class.
+
+## Usage
+[ @TODO FILL THIS IN]
+<!-- To use the plugin, simply instantiate it and register it with Core:
+
+```js
+const saytPlugin = new SaytPlugin(/* options */);
+core.register(saytPlugin);
+```
+The plugin registers an instance of the [Sayt client](https://www.npmjs.com/package/sayt) with Core.
+
+The SaytPlugin constructor can accept options to configure the exposed Sayt client. See the [SaytConfig interface](https://github.com/groupby/sayt-client/blob/develop/src/core/sayt.ts#L77) for available options. -->

--- a/packages/@sfx/search-driver-plugin/karma.conf.js
+++ b/packages/@sfx/search-driver-plugin/karma.conf.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../karma.conf.js');

--- a/packages/@sfx/search-driver-plugin/package.json
+++ b/packages/@sfx/search-driver-plugin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sfx/search-driver-plugin",
+  "version": "0.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "module": "src/index.ts",
+  "scripts": {
+    "build": "../../../scripts/build.sh",
+    "dev": "nodemon --config ../../../nodemon.json --exec npm run build",
+    "test": "nyc mocha",
+    "tdd": "nodemon --config ../../../nodemon.test.json --exec npm test",
+    "test:browser": "karma start karma.conf.js",
+    "tdd:browser": "karma start karma.conf.js --no-single-run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/groupby/sfx-logic.git",
+    "directory": "packages/@sfx/search-driver-plugin"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/@sfx/search-driver-plugin/package.json
+++ b/packages/@sfx/search-driver-plugin/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "dist/index.js",
   "module": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "esnext": "esnext/index.js",
   "scripts": {
     "build": "../../../scripts/build.sh",
     "dev": "nodemon --config ../../../nodemon.json --exec npm run build",

--- a/packages/@sfx/search-driver-plugin/src/events.ts
+++ b/packages/@sfx/search-driver-plugin/src/events.ts
@@ -1,3 +1,15 @@
+/**
+ * Fired to request a search. Its payload is the search term to use.
+ */
 export const SEARCH_REQUEST_EVENT = 'sfx::search_request';
+
+/**
+ * Fired when a search response has been received from the server.
+ * The payload is the search response.
+ */
 export const SEARCH_RESPONSE_EVENT = 'sfx::search_response';
+
+/**
+ * Fired when an error has occurred during a search request.
+ */
 export const SEARCH_ERROR_EVENT = 'sfx::search_error';

--- a/packages/@sfx/search-driver-plugin/src/events.ts
+++ b/packages/@sfx/search-driver-plugin/src/events.ts
@@ -1,2 +1,3 @@
 export const SEARCH_REQUEST_EVENT = 'sfx::search_request';
 export const SEARCH_RESPONSE_EVENT = 'sfx::search_response';
+export const SEARCH_ERROR_EVENT = 'sfx::search_error';

--- a/packages/@sfx/search-driver-plugin/src/events.ts
+++ b/packages/@sfx/search-driver-plugin/src/events.ts
@@ -1,0 +1,2 @@
+export const SEARCH_REQUEST_EVENT = 'sfx::search_request';
+export const SEARCH_RESPONSE_EVENT = 'sfx::search_response';

--- a/packages/@sfx/search-driver-plugin/src/index.ts
+++ b/packages/@sfx/search-driver-plugin/src/index.ts
@@ -1,2 +1,1 @@
 export { default as SearchDriverPlugin } from './search-driver-plugin';
-// export * from 'search-driver';

--- a/packages/@sfx/search-driver-plugin/src/index.ts
+++ b/packages/@sfx/search-driver-plugin/src/index.ts
@@ -1,0 +1,2 @@
+export { default as SearchDriverPlugin } from './search-driver-plugin';
+// export * from 'search-driver';

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -5,7 +5,7 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
  * This plugin is responsible for exposing events that allow
  * for interacting with GroupBy's Search API.
  */
- export default class SearchDriverPlugin implements Plugin {
+export default class SearchDriverPlugin implements Plugin {
   get metadata(): PluginMetadata {
     return {
       name: 'search-driver',

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -2,8 +2,8 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
 // import { Sayt, SaytConfig } from 'sayt';
 
 /**
- * This plugin is responsible for exposing an instance of sayt
- * to Core.
+ * This plugin is responsible for exposing events that allow
+ * for interacting with GroupBy's Search API.
  */
  export default class SearchDriverPlugin implements Plugin {
   get metadata(): PluginMetadata {

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -65,11 +65,17 @@ export default class SearchDriverPlugin implements Plugin {
   /**
    * @TODO Ensure `event` is of the correct interface.
    */
-  fetchSearchData(event: CustomEvent): void {
-    // const searchTerm = event.detail.searchTerm;
+  fetchSearchData(event: SearchRequestEvent): void {
+    const searchTerm = event.detail.searchTerm;
     // @TODO Get search term from data
     // @TODO Ask search API for results
     // @TODO Transform data on promise fulfillment (or by passing callback)
     // @TODO Emit event with final data
+  }
+}
+
+export interface SearchRequestEvent {
+  detail: {
+    searchTerm: string;
   }
 }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -73,5 +73,3 @@ export default class SearchDriverPlugin implements Plugin {
     // @TODO Emit event with final data
   }
 }
-
-interface SearchDriverOptions {}

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -19,6 +19,16 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   core: PluginRegistry;
 
   /**
+   * Name of the events plugin.
+   */
+  eventsPluginName: string = 'dom_events';
+
+  /**
+   * Event name to listen for Search requests.
+   */
+  searchDataEvent: string = 'sfx::search_fetch_data';
+
+  /**
    * This method needs to exist for compatibility with Core.
    */
   constructor(options?: SearchDriverOptions) {}
@@ -35,12 +45,20 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
    */
   ready() {
     // @TODO Attach listeners for events
+    this.core[this.eventsPluginName].registerListener(this.searchDataEvent, this.fetchSearchData);
   }
 
   /**
    * @TODO Remove event listeners
    */
   unregister(): void {
+  }
+
+  /**
+   * @TODO Ensure `event` is of the correct interface.
+   */
+  fetchSearchData(event: CustomEvent): void {
+
   }
 }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -28,35 +28,46 @@ export default class SearchDriverPlugin implements Plugin {
   eventsPluginName: string = 'dom_events';
 
   /**
-   * This method needs to exist for compatibility with Core.
+   * Constructs a new instance of the plugin and binds the necessary
+   * callbacks.
    */
   constructor() {
     this.fetchSearchData = this.fetchSearchData.bind(this);
   }
 
   /**
-   * Accepts the exposed values of all plugins and saves them for later.
+   * Saves the plugin registry for later use. This plugin does not
+   * expose a value.
+   *
+   * @param plugins the plugin registry to use.
    */
   register(plugins: PluginRegistry): void {
     this.core = plugins;
   }
 
   /**
-   * 
+   * Registers event listeners. The following events are listened for:
+   *
+   * - [[SEARCH_REQUEST_EVENT]]
    */
   ready() {
     this.core[this.eventsPluginName].registerListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
   }
 
   /**
-   *
+   * Unregisters event listeners.
    */
   unregister(): void {
     this.core[this.eventsPluginName].unregisterListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
   }
 
   /**
-   * @TODO Ensure `event` is of the correct interface.
+   * Performs a search with the given search term and emits the result
+   * through an event. The result is emitted in a
+   * [[SEARCH_RESPONSE_EVENT]] event. If the search fails for any
+   * reason, a [[SEARCH_ERROR_EVENT]] is dispatched with the error.
+   *
+   * @param event the event whose payload is the search term.
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
     const searchTerm = event.detail;
@@ -70,4 +81,8 @@ export default class SearchDriverPlugin implements Plugin {
   }
 }
 
+/**
+ * The type of the search request event payload. The payload is the
+ * search term.
+ */
 export type SearchRequestPayload = string;

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -64,9 +64,9 @@ export default class SearchDriverPlugin implements Plugin {
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
       })
-     .catch((e) => {
-       this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
-     });
+      .catch((e) => {
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
+      });
   }
 }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -58,7 +58,11 @@ export default class SearchDriverPlugin implements Plugin {
    * @TODO Ensure `event` is of the correct interface.
    */
   fetchSearchData(event: CustomEvent): void {
-
+    // const searchTerm = event.detail.searchTerm;
+    // @TODO Get search term from data
+    // @TODO Ask search API for results
+    // @TODO Transform data on promise fulfillment (or by passing callback)
+    // @TODO Emit event with final data
   }
 }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -14,17 +14,20 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   }
 
   /**
-   * 
+   * A reference to the registry of plugins for later use.
    */
-  constructor() {
-  }
+  core: PluginRegistry;
+
+  /**
+   * Currently no need for an instructor, but the method needs to
+   * exist for compatibility with Core.
+   */
+  constructor(options?: object) {}
 
   /**
    * 
    */
-  register(): object {
-    return {
-
-    }
+  register(plugins: PluginRegistry): void {
+    this.core = plugins;
   }
 }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -13,7 +13,7 @@ export default class SearchDriverPlugin implements Plugin {
   get metadata(): PluginMetadata {
     return {
       name: 'search_driver',
-      depends: ['dom_events', 'search'],
+      depends: [this.eventsPluginName, 'search'],
     };
   }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -8,7 +8,7 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
 export default class SearchDriverPlugin implements Plugin {
   get metadata(): PluginMetadata {
     return {
-      name: 'search-driver',
+      name: 'search_driver',
       depends: ['dom_events', 'search'],
     };
   }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -1,4 +1,5 @@
 import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
+import { BridgeQuery, Results } from '@sfx/search-plugin';
 import {
   SEARCH_REQUEST_EVENT,
   SEARCH_RESPONSE_EVENT,
@@ -71,13 +72,22 @@ export default class SearchDriverPlugin implements Plugin {
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
     const searchTerm = event.detail;
-    this.core.search.search(searchTerm)
+    this.sendSearchApiRequest(searchTerm)
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
       })
       .catch((e) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
       });
+  }
+
+  /**
+   * Sends a search request using the GroupBy API.
+   *
+   * @param query the query to send.
+   */
+  sendSearchApiRequest(query: BridgeQuery): Promise<Results> {
+    return this.core.search.search(query);
   }
 }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -57,6 +57,7 @@ export default class SearchDriverPlugin implements Plugin {
    * @TODO Remove event listeners
    */
   unregister(): void {
+    this.core[this.eventsPluginName].unregisterListener(this.searchDataEvent, this.fetchSearchData);
   }
 
   /**

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -1,0 +1,30 @@
+import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
+// import { Sayt, SaytConfig } from 'sayt';
+
+/**
+ * This plugin is responsible for exposing an instance of sayt
+ * to Core.
+ */
+ export default class SearchDriverPlugin implements Plugin {
+  get metadata(): PluginMetadata {
+    return {
+      name: 'search-driver',
+      depends: [],
+    };
+  }
+
+  /**
+   * 
+   */
+  constructor() {
+  }
+
+  /**
+   * 
+   */
+  register(): object {
+    return {
+
+    }
+  }
+}

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -30,4 +30,11 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   register(plugins: PluginRegistry): void {
     this.core = plugins;
   }
+
+  /**
+   * 
+   */
+  ready() {
+    // @TODO Attach listeners for events
+  }
 }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -65,9 +65,9 @@ export default class SearchDriverPlugin implements Plugin {
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
     const searchTerm = event.detail.searchTerm;
     this.core.search.search(searchTerm)
-    //  .then((data) => {
-    //    this.core[this.eventsPluginName].dispatchEvent(this.searchResponseEvent, data);
-    //  })
+      .then((results) => {
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
+      })
     //  .catch((e) => {
     //    this.core[this.eventsPluginName].dispatchEvent(this.searchErrorEvent, e);
     //  });

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -1,4 +1,6 @@
 import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
+import { Request } from '@sfx/search-plugin';
+import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT } from './events';
 // import { Sayt, SaytConfig } from 'sayt';
 
 /**
@@ -24,11 +26,6 @@ export default class SearchDriverPlugin implements Plugin {
   eventsPluginName: string = 'dom_events';
 
   /**
-   * Name of the search API plugin.
-   */
-  searchPluginName: string = 'search';
-
-  /**
    * Event name to listen for Search requests.
    */
   searchDataEvent: string = 'sfx::search_fetch_data';
@@ -52,21 +49,29 @@ export default class SearchDriverPlugin implements Plugin {
    */
   ready() {
     // @TODO Attach listeners for events
-    this.core[this.eventsPluginName].registerListener(this.searchDataEvent, this.fetchSearchData);
+    this.core[this.eventsPluginName].registerListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
   }
 
   /**
    * @TODO Remove event listeners
    */
   unregister(): void {
-    this.core[this.eventsPluginName].unregisterListener(this.searchDataEvent, this.fetchSearchData);
+    this.core[this.eventsPluginName].unregisterListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
   }
 
   /**
    * @TODO Ensure `event` is of the correct interface.
    */
-  fetchSearchData(event: SearchRequestEvent): void {
+  fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
     const searchTerm = event.detail.searchTerm;
+    //this.core.search.search(searchTerm)
+    //  .then((data) => {
+    //    this.core[this.eventsPluginName].dispatchEvent(this.searchResponseEvent, data);
+    //  })
+    //  .catch((e) => {
+    //    this.core[this.eventsPluginName].dispatchEvent(this.searchErrorEvent, e);
+    //  });
+
     // @TODO Get search term from data
     // @TODO Ask search API for results
     // @TODO Transform data on promise fulfillment (or by passing callback)
@@ -74,8 +79,6 @@ export default class SearchDriverPlugin implements Plugin {
   }
 }
 
-export interface SearchRequestEvent {
-  detail: {
-    searchTerm: string;
-  }
+export interface SearchRequestPayload {
+  searchTerm: string;
 }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -45,12 +45,11 @@ export default class SearchDriverPlugin implements Plugin {
    * 
    */
   ready() {
-    // @TODO Attach listeners for events
     this.core[this.eventsPluginName].registerListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
   }
 
   /**
-   * @TODO Remove event listeners
+   *
    */
   unregister(): void {
     this.core[this.eventsPluginName].unregisterListener(SEARCH_REQUEST_EVENT, this.fetchSearchData);
@@ -68,11 +67,6 @@ export default class SearchDriverPlugin implements Plugin {
      .catch((e) => {
        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
      });
-
-    // @TODO Get search term from data
-    // @TODO Ask search API for results
-    // @TODO Transform data on promise fulfillment (or by passing callback)
-    // @TODO Emit event with final data
   }
 }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -9,7 +9,7 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   get metadata(): PluginMetadata {
     return {
       name: 'search-driver',
-      depends: [],
+      depends: ['dom_events', 'search_data_source'],
     };
   }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -1,6 +1,10 @@
 import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
 import { Request } from '@sfx/search-plugin';
-import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT } from './events';
+import {
+  SEARCH_REQUEST_EVENT,
+  SEARCH_RESPONSE_EVENT,
+  SEARCH_ERROR_EVENT,
+} from './events';
 // import { Sayt, SaytConfig } from 'sayt';
 
 /**
@@ -68,9 +72,9 @@ export default class SearchDriverPlugin implements Plugin {
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
       })
-    //  .catch((e) => {
-    //    this.core[this.eventsPluginName].dispatchEvent(this.searchErrorEvent, e);
-    //  });
+     .catch((e) => {
+       this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
+     });
 
     // @TODO Get search term from data
     // @TODO Ask search API for results

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -9,7 +9,7 @@ export default class SearchDriverPlugin implements Plugin {
   get metadata(): PluginMetadata {
     return {
       name: 'search-driver',
-      depends: ['dom_events', 'search_data_source'],
+      depends: ['dom_events', 'search'],
     };
   }
 
@@ -22,6 +22,11 @@ export default class SearchDriverPlugin implements Plugin {
    * Name of the events plugin.
    */
   eventsPluginName: string = 'dom_events';
+
+  /**
+   * Name of the search API plugin.
+   */
+  searchPluginName: string = 'search';
 
   /**
    * Event name to listen for Search requests.

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -59,7 +59,7 @@ export default class SearchDriverPlugin implements Plugin {
    * @TODO Ensure `event` is of the correct interface.
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
-    const searchTerm = event.detail.searchTerm;
+    const searchTerm = event.detail;
     this.core.search.search(searchTerm)
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
@@ -70,6 +70,4 @@ export default class SearchDriverPlugin implements Plugin {
   }
 }
 
-export interface SearchRequestPayload {
-  searchTerm: string;
-}
+export type SearchRequestPayload = string;

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -36,6 +36,12 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   ready() {
     // @TODO Attach listeners for events
   }
+
+  /**
+   * @TODO Remove event listeners
+   */
+  unregister(): void {
+  }
 }
 
 interface SearchDriverOptions {}

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -36,7 +36,9 @@ export default class SearchDriverPlugin implements Plugin {
   /**
    * This method needs to exist for compatibility with Core.
    */
-  constructor(options?: SearchDriverOptions) {}
+  constructor() {
+    this.fetchSearchData = this.fetchSearchData.bind(this);
+  }
 
   /**
    * Accepts the exposed values of all plugins and saves them for later.

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -64,7 +64,7 @@ export default class SearchDriverPlugin implements Plugin {
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
     const searchTerm = event.detail.searchTerm;
-    //this.core.search.search(searchTerm)
+    this.core.search.search(searchTerm)
     //  .then((data) => {
     //    this.core[this.eventsPluginName].dispatchEvent(this.searchResponseEvent, data);
     //  })

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -1,11 +1,9 @@
 import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
-import { Request } from '@sfx/search-plugin';
 import {
   SEARCH_REQUEST_EVENT,
   SEARCH_RESPONSE_EVENT,
   SEARCH_ERROR_EVENT,
 } from './events';
-// import { Sayt, SaytConfig } from 'sayt';
 
 /**
  * This plugin is responsible for exposing events that allow

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -19,13 +19,12 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
   core: PluginRegistry;
 
   /**
-   * Currently no need for an instructor, but the method needs to
-   * exist for compatibility with Core.
+   * This method needs to exist for compatibility with Core.
    */
-  constructor(options?: object) {}
+  constructor(options?: SearchDriverOptions) {}
 
   /**
-   * 
+   * Accepts the exposed values of all plugins and saves them for later.
    */
   register(plugins: PluginRegistry): void {
     this.core = plugins;
@@ -38,3 +37,5 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@sfx/core';
     // @TODO Attach listeners for events
   }
 }
+
+interface SearchDriverOptions {}

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -28,11 +28,6 @@ export default class SearchDriverPlugin implements Plugin {
   eventsPluginName: string = 'dom_events';
 
   /**
-   * Event name to listen for Search requests.
-   */
-  searchDataEvent: string = 'sfx::search_fetch_data';
-
-  /**
    * This method needs to exist for compatibility with Core.
    */
   constructor() {

--- a/packages/@sfx/search-driver-plugin/test/setup.ts
+++ b/packages/@sfx/search-driver-plugin/test/setup.ts
@@ -1,0 +1,1 @@
+import '../../../../test/setup';

--- a/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
@@ -4,6 +4,6 @@ import { SearchDriverPlugin as SearchDriverExport } from '../../../src/index';
 
 describe('Entry point', () => {
   it('should export SearchDriverPlugin', () => {
-    expect(SearchDriverPlugin).to.equal(SearchDriverExport);
+    expect(SearchDriverExport).to.equal(SearchDriverPlugin);
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
@@ -1,0 +1,9 @@
+import { expect } from '../../utils';
+import { default as SearchDriverPlugin } from '../../../src/search-driver-plugin';
+import { SearchDriverPlugin as SearchDriverExport } from '../../../src/index';
+
+describe('Entry point', () => {
+  it('should export SaytPlugin', () => {
+    expect(SearchDriverPlugin).to.equal(SearchDriverExport);
+  });
+});

--- a/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/index.test.ts
@@ -3,7 +3,7 @@ import { default as SearchDriverPlugin } from '../../../src/search-driver-plugin
 import { SearchDriverPlugin as SearchDriverExport } from '../../../src/index';
 
 describe('Entry point', () => {
-  it('should export SaytPlugin', () => {
+  it('should export SearchDriverPlugin', () => {
     expect(SearchDriverPlugin).to.equal(SearchDriverExport);
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -11,7 +11,7 @@ describe('SearchDriverPlugin', () => {
 
   describe('metadata getter', () => {
     it('should have the name `sayt`', () => {
-      expect(searchDriverPlugin.metadata.name).to.equal('search-driver');
+      expect(searchDriverPlugin.metadata.name).to.equal('search_driver');
     });
 
     it('should not specify any dependencies', () => {

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -60,10 +60,6 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('unregister()', () => {
-    it('should exist as a function', () => {
-      expect(searchDriverPlugin.unregister).to.be.a('function');
-    });
-
     it('should unregister the search request event listener', () => {
       const eventsPluginName = searchDriverPlugin.eventsPluginName = 'events-plugin';
       const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -47,4 +47,10 @@ describe('SearchDriverPlugin', () => {
       expect(searchDriverPlugin.ready).to.be.a('function');
     });
   });
+
+  describe('unregister()', () => {
+    it('should exist as a function', () => {
+      expect(searchDriverPlugin.unregister).to.be.a('function');
+    });
+  });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,40 +1,44 @@
 import { expect, sinon, stub } from '../../utils';
-import SaytPlugin from '../../../src/search-driver-plugin';
-import * as SaytPackage from 'sayt';
+import SearchDriverPlugin from '../../../src/search-driver-plugin';
+import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
   let searchDriverPlugin: any;
 
   beforeEach(() => {
+    searchDriverPlugin = new SearchDriverPlugin();
   });
 
   describe('metadata getter', () => {
-    // it('should have the name `sayt`', () => {
-    //   expect(saytPlugin.metadata.name).to.equal('sayt');
-    // });
+    it('should have the name `sayt`', () => {
+      expect(searchDriverPlugin.metadata.name).to.equal('search-driver');
+    });
 
-    // it('should not specify any dependencies', () => {
-    //   expect(saytPlugin.metadata.depends).to.deep.equal([]);
-    // });
+    it('should not specify any dependencies', () => {
+      expect(searchDriverPlugin.metadata.depends).to.deep.equal([
+        'dom_events',
+        'search_data_source',
+      ]);
+    });
   });
 
   describe('constructor()', () => {
     // it('should create a new instance of Sayt with options', () => {
     //   const saytInstance = { a: 'a' };
-    //   const Sayt = stub(SaytPackage, 'Sayt').returns(saytInstance);
+    //   const Sayt = stub(SearchDriverPackage, 'Sayt').returns(saytInstance);
     //   const options: any = { b: 'b' };
-    //   saytPlugin = new SaytPlugin(options);
+    //   searchDriverPlugin = new searchDriverPlugin(options);
 
     //   expect(Sayt).to.be.calledWith(options);
     //   expect(Sayt.calledWithNew()).to.be.true;
-    //   expect(saytPlugin.sayt).to.equal(saytInstance);
+    //   expect(searchDriverPlugin.sayt).to.equal(saytInstance);
     // });
   });
 
   describe('register()', () => {
     // it('should return the sayt instance', () => {
-    //   const saytInstance = saytPlugin.sayt = { a: 'a' };
-    //   const registerReturnValue = saytPlugin.register();
+    //   const saytInstance = searchDriverPlugin.sayt = { a: 'a' };
+    //   const registerReturnValue = searchDriverPlugin.register();
 
     //   expect(registerReturnValue).to.equal(saytInstance);
     // });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,7 +1,6 @@
-import { expect, sinon, spy, stub } from '../../utils';
+import { expect, spy } from '../../utils';
 import SearchDriverPlugin from '@sfx/search-driver-plugin/src/search-driver-plugin';
 import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT, SEARCH_ERROR_EVENT } from '@sfx/search-driver-plugin/src/events';
-import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
   const eventsPluginName = 'dom_events';
@@ -37,7 +36,6 @@ describe('SearchDriverPlugin', () => {
 
   describe('ready()', () => {
     it('should register a search request event listener', () => {
-      const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';
       const registerListener = spy();
       searchDriverPlugin.core = {
         [eventsPluginName]: {
@@ -53,7 +51,6 @@ describe('SearchDriverPlugin', () => {
 
   describe('unregister()', () => {
     it('should unregister the search request event listener', () => {
-      const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';
       const unregisterListener = spy();
       searchDriverPlugin.core = {
         [eventsPluginName]: {

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -4,7 +4,7 @@ import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT, SEARCH_ERROR_EVENT } from 
 import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
-  const eventsPluginName = 'events';
+  const eventsPluginName = 'dom_events';
   let searchDriverPlugin;
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('SearchDriverPlugin', () => {
 
     it('should specify dependencies', () => {
       expect(searchDriverPlugin.metadata.depends).to.have.members([
-        'dom_events',
+        eventsPluginName,
         'search',
       ]);
     });
@@ -73,7 +73,7 @@ describe('SearchDriverPlugin', () => {
       const search = spy(() => Promise.resolve());
       searchDriverPlugin.core = {
         search: { search },
-        events: { dispatchEvent: () => {} },
+        [eventsPluginName]: { dispatchEvent: () => {} },
       };
 
       searchDriverPlugin.fetchSearchData({ detail: searchTerm } as any);
@@ -89,7 +89,7 @@ describe('SearchDriverPlugin', () => {
       });
       searchDriverPlugin.core = {
         search: { search: () => Promise.resolve(results) },
-        events: { dispatchEvent },
+        [eventsPluginName]: { dispatchEvent },
       };
 
       searchDriverPlugin.fetchSearchData({ detail: 'search' } as any);
@@ -103,7 +103,7 @@ describe('SearchDriverPlugin', () => {
       });
       searchDriverPlugin.core = {
         search: { search: () => Promise.reject(error) },
-        events: { dispatchEvent },
+        [eventsPluginName]: { dispatchEvent },
       };
 
       searchDriverPlugin.fetchSearchData({ detail: 'search' } as any);

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -66,4 +66,10 @@ describe('SearchDriverPlugin', () => {
       expect(unregisterListener).to.be.calledWith(SEARCH_REQUEST_EVENT, searchDriverPlugin.fetchSearchData);
     });
   });
+
+  describe('fetchSearchData()', () => {
+    it('should search with the given search term');
+    it('should dispatch an event with the results');
+    it('should dispatch an error event when the search fails');
+  });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -15,9 +15,9 @@ describe('SearchDriverPlugin', () => {
     });
 
     it('should not specify any dependencies', () => {
-      expect(searchDriverPlugin.metadata.depends).to.deep.equal([
+      expect(searchDriverPlugin.metadata.depends).to.have.members([
         'dom_events',
-        'search_data_source',
+        'search',
       ]);
     });
   });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -68,7 +68,16 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('fetchSearchData()', () => {
-    it('should search with the given search term');
+    it('should search with the given search term', () => {
+      const searchTerm = 'search term';
+      const search = spy(() => Promise.resolve());
+      searchDriverPlugin.core = { search: { search } };
+
+      searchDriverPlugin.fetchSearchData({ detail: { searchTerm } } as any);
+
+      expect(search).to.be.calledWith(searchTerm);
+    });
+
     it('should dispatch an event with the results');
     it('should dispatch an error event when the search fails');
   });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,5 +1,6 @@
 import { expect, sinon, spy, stub } from '../../utils';
 import SearchDriverPlugin from '@sfx/search-driver-plugin/src/search-driver-plugin';
+import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT } from '@sfx/search-driver-plugin/src/events';
 import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
@@ -45,7 +46,7 @@ describe('SearchDriverPlugin', () => {
 
       searchDriverPlugin.ready();
 
-      expect(registerListener).to.be.calledWith(searchDataEvent, searchDriverPlugin.fetchSearchData);
+      expect(registerListener).to.be.calledWith(SEARCH_REQUEST_EVENT, searchDriverPlugin.fetchSearchData);
     });
   });
 
@@ -62,7 +63,7 @@ describe('SearchDriverPlugin', () => {
 
       searchDriverPlugin.unregister();
 
-      expect(unregisterListener).to.be.calledWith(searchDataEvent, searchDriverPlugin.fetchSearchData);
+      expect(unregisterListener).to.be.calledWith(SEARCH_REQUEST_EVENT, searchDriverPlugin.fetchSearchData);
     });
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -25,7 +25,7 @@ describe('SearchDriverPlugin', () => {
   describe('constructor()', () => {
     it('should accept an options object', () => {
       const callback = () => {
-        searchDriverPlugin = new SearchDriverPlugin({ 'a': 1, 'b': 2});
+        searchDriverPlugin = new SearchDriverPlugin({ a: 1, b: 2 });
       }
 
       expect(callback).not.to.throw();
@@ -34,7 +34,7 @@ describe('SearchDriverPlugin', () => {
 
   describe('register()', () => {
     it('should save the plugin registry for future use', () => {
-      const registry = { 'a': 1, 'b': 2} as any;
+      const registry = { a: 1, b: 2 } as any;
 
       searchDriverPlugin.register(registry);
 

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -10,11 +10,11 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('metadata getter', () => {
-    it('should have the name `sayt`', () => {
+    it('should have the name `search_driver`', () => {
       expect(searchDriverPlugin.metadata.name).to.equal('search_driver');
     });
 
-    it('should not specify any dependencies', () => {
+    it('should specify dependencies', () => {
       expect(searchDriverPlugin.metadata.depends).to.have.members([
         'dom_events',
         'search',

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -55,13 +55,28 @@ describe('SearchDriverPlugin', () => {
 
       searchDriverPlugin.ready();
 
-      expect(registerListener).to.be.calledWith(searchDataEvent);
+      expect(registerListener).to.be.calledWith(searchDataEvent, searchDriverPlugin.fetchSearchData);
     });
   });
 
   describe('unregister()', () => {
     it('should exist as a function', () => {
       expect(searchDriverPlugin.unregister).to.be.a('function');
+    });
+
+    it('should unregister the search request event listener', () => {
+      const eventsPluginName = searchDriverPlugin.eventsPluginName = 'events-plugin';
+      const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';
+      const unregisterListener = spy();
+      searchDriverPlugin.core = {
+        [eventsPluginName]: {
+          unregisterListener,
+        },
+      };
+
+      searchDriverPlugin.unregister();
+
+      expect(unregisterListener).to.be.calledWith(searchDataEvent, searchDriverPlugin.fetchSearchData);
     });
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,6 +1,6 @@
 import { expect, sinon, spy, stub } from '../../utils';
 import SearchDriverPlugin from '@sfx/search-driver-plugin/src/search-driver-plugin';
-import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT } from '@sfx/search-driver-plugin/src/events';
+import { SEARCH_REQUEST_EVENT, SEARCH_RESPONSE_EVENT, SEARCH_ERROR_EVENT } from '@sfx/search-driver-plugin/src/events';
 import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
@@ -95,6 +95,18 @@ describe('SearchDriverPlugin', () => {
       searchDriverPlugin.fetchSearchData({ detail: { searchTerm: '' } } as any);
     });
 
-    it('should dispatch an error event when the search fails');
+    it('should dispatch an error event when the search fails', (done) => {
+      const error = 'error-object';
+      const dispatchEvent = spy(() => {
+        expect(dispatchEvent).to.be.calledWith(SEARCH_ERROR_EVENT, error);
+        done();
+      });
+      searchDriverPlugin.core = {
+        search: { search: () => Promise.reject(error) },
+        events: { dispatchEvent },
+      };
+
+      searchDriverPlugin.fetchSearchData({ detail: { searchTerm: '' } } as any);
+    });
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -43,10 +43,6 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('ready()', () => {
-    it('should exist as a function', () => {
-      expect(searchDriverPlugin.ready).to.be.a('function');
-    });
-
     it('should register a search request event listener', () => {
       const eventsPluginName = searchDriverPlugin.eventsPluginName = 'events-plugin';
       const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -76,7 +76,7 @@ describe('SearchDriverPlugin', () => {
         events: { dispatchEvent: () => {} },
       };
 
-      searchDriverPlugin.fetchSearchData({ detail: { searchTerm } } as any);
+      searchDriverPlugin.fetchSearchData({ detail: searchTerm } as any);
 
       expect(search).to.be.calledWith(searchTerm);
     });
@@ -92,7 +92,7 @@ describe('SearchDriverPlugin', () => {
         events: { dispatchEvent },
       };
 
-      searchDriverPlugin.fetchSearchData({ detail: { searchTerm: '' } } as any);
+      searchDriverPlugin.fetchSearchData({ detail: 'search' } as any);
     });
 
     it('should dispatch an error event when the search fails', (done) => {
@@ -106,7 +106,7 @@ describe('SearchDriverPlugin', () => {
         events: { dispatchEvent },
       };
 
-      searchDriverPlugin.fetchSearchData({ detail: { searchTerm: '' } } as any);
+      searchDriverPlugin.fetchSearchData({ detail: 'search' } as any);
     });
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,0 +1,42 @@
+import { expect, sinon, stub } from '../../utils';
+import SaytPlugin from '../../../src/search-driver-plugin';
+import * as SaytPackage from 'sayt';
+
+describe('SearchDriverPlugin', () => {
+  let searchDriverPlugin: any;
+
+  beforeEach(() => {
+  });
+
+  describe('metadata getter', () => {
+    // it('should have the name `sayt`', () => {
+    //   expect(saytPlugin.metadata.name).to.equal('sayt');
+    // });
+
+    // it('should not specify any dependencies', () => {
+    //   expect(saytPlugin.metadata.depends).to.deep.equal([]);
+    // });
+  });
+
+  describe('constructor()', () => {
+    // it('should create a new instance of Sayt with options', () => {
+    //   const saytInstance = { a: 'a' };
+    //   const Sayt = stub(SaytPackage, 'Sayt').returns(saytInstance);
+    //   const options: any = { b: 'b' };
+    //   saytPlugin = new SaytPlugin(options);
+
+    //   expect(Sayt).to.be.calledWith(options);
+    //   expect(Sayt.calledWithNew()).to.be.true;
+    //   expect(saytPlugin.sayt).to.equal(saytInstance);
+    // });
+  });
+
+  describe('register()', () => {
+    // it('should return the sayt instance', () => {
+    //   const saytInstance = saytPlugin.sayt = { a: 'a' };
+    //   const registerReturnValue = saytPlugin.register();
+
+    //   expect(registerReturnValue).to.equal(saytInstance);
+    // });
+  });
+});

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -1,5 +1,5 @@
-import { expect, sinon, stub } from '../../utils';
-import SearchDriverPlugin from '../../../src/search-driver-plugin';
+import { expect, sinon, spy, stub } from '../../utils';
+import SearchDriverPlugin from '@sfx/search-driver-plugin/src/search-driver-plugin';
 import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
@@ -45,6 +45,21 @@ describe('SearchDriverPlugin', () => {
   describe('ready()', () => {
     it('should exist as a function', () => {
       expect(searchDriverPlugin.ready).to.be.a('function');
+    });
+
+    it('should register a search request event listener', () => {
+      const eventsPluginName = searchDriverPlugin.eventsPluginName = 'events-plugin';
+      const searchDataEvent = searchDriverPlugin.searchDataEvent = 'search-event';
+      const registerListener = spy();
+      searchDriverPlugin.core = {
+        [eventsPluginName]: {
+          registerListener,
+        },
+      };
+
+      searchDriverPlugin.ready();
+
+      expect(registerListener).to.be.calledWith(searchDataEvent);
     });
   });
 

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -22,16 +22,6 @@ describe('SearchDriverPlugin', () => {
     });
   });
 
-  describe('constructor()', () => {
-    it('should accept an options object', () => {
-      const callback = () => {
-        searchDriverPlugin = new SearchDriverPlugin({ a: 1, b: 2 });
-      }
-
-      expect(callback).not.to.throw();
-    });
-  });
-
   describe('register()', () => {
     it('should save the plugin registry for future use', () => {
       const registry: any = { a: 1, b: 2 };

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -41,4 +41,10 @@ describe('SearchDriverPlugin', () => {
       expect(searchDriverPlugin.core).to.equal(registry);
     });
   });
+
+  describe('ready()', () => {
+    it('should exist as a function', () => {
+      expect(searchDriverPlugin.ready).to.be.a('function');
+    });
+  });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -23,24 +23,22 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('constructor()', () => {
-    // it('should create a new instance of Sayt with options', () => {
-    //   const saytInstance = { a: 'a' };
-    //   const Sayt = stub(SearchDriverPackage, 'Sayt').returns(saytInstance);
-    //   const options: any = { b: 'b' };
-    //   searchDriverPlugin = new searchDriverPlugin(options);
+    it('should accept an options object', () => {
+      const callback = () => {
+        searchDriverPlugin = new SearchDriverPlugin({ 'a': 1, 'b': 2});
+      }
 
-    //   expect(Sayt).to.be.calledWith(options);
-    //   expect(Sayt.calledWithNew()).to.be.true;
-    //   expect(searchDriverPlugin.sayt).to.equal(saytInstance);
-    // });
+      expect(callback).not.to.throw();
+    });
   });
 
   describe('register()', () => {
-    // it('should return the sayt instance', () => {
-    //   const saytInstance = searchDriverPlugin.sayt = { a: 'a' };
-    //   const registerReturnValue = searchDriverPlugin.register();
+    it('should save the plugin registry for future use', () => {
+      const registry = { 'a': 1, 'b': 2} as any;
 
-    //   expect(registerReturnValue).to.equal(saytInstance);
-    // });
+      searchDriverPlugin.register(registry);
+
+      expect(searchDriverPlugin.core).to.equal(registry);
+    });
   });
 });

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -3,7 +3,7 @@ import SearchDriverPlugin from '@sfx/search-driver-plugin/src/search-driver-plug
 import * as SearchDriverPackage from 'sayt';
 
 describe('SearchDriverPlugin', () => {
-  let searchDriverPlugin: any;
+  let searchDriverPlugin;
 
   beforeEach(() => {
     searchDriverPlugin = new SearchDriverPlugin();
@@ -34,7 +34,7 @@ describe('SearchDriverPlugin', () => {
 
   describe('register()', () => {
     it('should save the plugin registry for future use', () => {
-      const registry = { a: 1, b: 2 } as any;
+      const registry: any = { a: 1, b: 2 };
 
       searchDriverPlugin.register(registry);
 

--- a/packages/@sfx/search-driver-plugin/test/utils.ts
+++ b/packages/@sfx/search-driver-plugin/test/utils.ts
@@ -1,0 +1,1 @@
+export * from '../../../../test/utils';

--- a/packages/@sfx/search-driver-plugin/tsconfig.esnext.json
+++ b/packages/@sfx/search-driver-plugin/tsconfig.esnext.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node"
+    ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es2015",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "esnext",
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "declaration": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/@sfx/search-driver-plugin/tsconfig.json
+++ b/packages/@sfx/search-driver-plugin/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node",
+      "mocha"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
The search driver is responsible for listening for events, making search requests when those events are received, and dispatching the results through other events.