### PR TITLE
SFX-198: Implement plugin unregistration

### DIFF
--- a/packages/@sfx/core/CHANGELOG.md
+++ b/packages/@sfx/core/CHANGELOG.md
@@ -8,5 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SFX-99: Added the `Core` module and related plugin interfaces.
   - The Core module manages the registration and unregistration of plugins.
-    Unregistration of individual plugins is not currently supported.
   - The package also exports the `Plugin`, `PluginMetadata`, and `PluginRegistry` interfaces.

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -9,6 +9,7 @@ import {
 import {
   DependencyGraph,
   createDependencyGraph,
+  mergeDependencyGraphs,
 } from './utils/dependencies';
 
 /**
@@ -74,6 +75,7 @@ export default class Core {
     }
 
     registerPlugins(plugins, this.registry, this.directory);
+    this.dependencyGraph = mergeDependencyGraphs(this.dependencyGraph, createDependencyGraph(plugins));
 
     initPlugins(plugins);
     readyPlugins(plugins);

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -6,6 +6,10 @@ import {
   registerPlugins,
   unregisterPlugins,
 } from './utils/core';
+import {
+  DependencyGraph,
+  createDependencyGraph,
+} from './utils/dependencies';
 
 /**
  * The core of the SF-X plugin system. This entity is responsible for
@@ -30,6 +34,13 @@ export default class Core {
    * Plugins do not have access to this directory.
    */
   directory: PluginDirectory = Object.create(null);
+
+  /**
+   * An object with plugin names mapped to the names of the plugins that
+   * depend on it. This dependency graph is represented as an adjacency
+   * list.
+   */
+  dependencyGraph: DependencyGraph = createDependencyGraph();
 
   /**
    * Register one or more plugins with Core.

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -81,6 +81,10 @@ export default class Core {
     readyPlugins(plugins);
   }
 
+  unregister(plugins: string[]) {
+    unregisterPlugins(plugins, this.registry, this.directory);
+  }
+
   /**
    * Unregisters all plugins. The plugin registry, directory and
    * dependency graph are all cleared. The optional `unregister`

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -10,6 +10,7 @@ import {
   DependencyGraph,
   createDependencyGraph,
   mergeDependencyGraphs,
+  removeFromDependencyGraph,
 } from './utils/dependencies';
 
 /**
@@ -83,6 +84,7 @@ export default class Core {
 
   unregister(plugins: string[]) {
     unregisterPlugins(plugins, this.registry, this.directory);
+    this.dependencyGraph = removeFromDependencyGraph(this.dependencyGraph, plugins);
   }
 
   /**

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -85,7 +85,7 @@ export default class Core {
   /**
    * Unregisters the given plugins. The plugin registry, directory and
    * dependency graph are all updated. The optional `unregister`
-   * function of each plugin is called with the plugin is unregistered.
+   * function of each plugin is called when the plugin is unregistered.
    * The order in which the plugins are unregistered is unspecified.
    *
    * @param plugins The names of the plugins to unregister.

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -83,8 +83,9 @@ export default class Core {
   }
 
   unregister(plugins: string[]) {
+    const updatedGraph = removeFromDependencyGraph(this.dependencyGraph, plugins);
     unregisterPlugins(plugins, this.registry, this.directory);
-    this.dependencyGraph = removeFromDependencyGraph(this.dependencyGraph, plugins);
+    this.dependencyGraph = updatedGraph;
   }
 
   /**

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -82,6 +82,15 @@ export default class Core {
     readyPlugins(plugins);
   }
 
+  /**
+   * Unregisters the given plugins. The plugin registry, directory and
+   * dependency graph are all updated. The optional `unregister`
+   * function of each plugin is called with the plugin is unregistered.
+   * The order in which the plugins are unregistered is unspecified.
+   *
+   * @param plugins The names of the plugins to unregister.
+   * @throws If unregistering a plugin will break a dependency.
+   */
   unregister(plugins: string[]) {
     const updatedGraph = removeFromDependencyGraph(this.dependencyGraph, plugins);
     unregisterPlugins(plugins, this.registry, this.directory);

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -91,7 +91,7 @@ export default class Core {
    * @param plugins The names of the plugins to unregister.
    * @throws If unregistering a plugin will break a dependency.
    */
-  unregister(plugins: string[]) {
+  unregister(plugins: string[]): void {
     const updatedGraph = removeFromDependencyGraph(this.dependencyGraph, plugins);
     unregisterPlugins(plugins, this.registry, this.directory);
     this.dependencyGraph = updatedGraph;

--- a/packages/@sfx/core/src/core.ts
+++ b/packages/@sfx/core/src/core.ts
@@ -82,12 +82,13 @@ export default class Core {
   }
 
   /**
-   * Unregisters all plugins. The plugin registry and directory are both
-   * cleared. The optional `unregister` function of each plugin is
-   * called when the plugin is unregistered. The order in which the
-   * plugins are unregistered is unspecified.
+   * Unregisters all plugins. The plugin registry, directory and
+   * dependency graph are all cleared. The optional `unregister`
+   * function of each plugin is called when the plugin is unregistered.
+   * The order in which the plugins are unregistered is unspecified.
    */
   unregisterAll() {
     unregisterPlugins(Object.keys(this.directory), this.registry, this.directory);
+    this.dependencyGraph = createDependencyGraph();
   }
 }

--- a/packages/@sfx/core/src/utils/core.ts
+++ b/packages/@sfx/core/src/utils/core.ts
@@ -79,7 +79,8 @@ export function readyPlugins(plugins: Plugin[]) {
 
 /**
  * Unregisters the plugins with the given names from the given registry
- * and directory.
+ * and directory. It is safe to attempt to unregister a plugin that is
+ * not registered.
  *
  * @param names The names of the plugins to unregister.
  * @param registry The registry from which to unregister the plugin's
@@ -89,7 +90,7 @@ export function readyPlugins(plugins: Plugin[]) {
 export function unregisterPlugins(names: string[], registry: PluginRegistry, directory: PluginDirectory) {
   names.forEach((name) => {
     const plugin = directory[name];
-    if (typeof plugin.unregister === 'function') {
+    if (plugin && typeof plugin.unregister === 'function') {
       plugin.unregister();
     }
   });

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -11,7 +11,7 @@ import { Plugin } from '../plugin';
  * are lists of the names of dependent plugins.
  */
 export interface DependencyGraph {
-  /** The names of each plugin's dependents. */
+  /** The names of each plugin's dependers. */
   [name: string]: string[];
 }
 

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -19,6 +19,10 @@ export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
   }, Object.create(null));
 }
 
+export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyGraph {
+  return Object.create(null);
+}
+
 /**
  * The type of the plugin dependency graph. The dependency graph is a
  * directed graph whose vertices are plugins and whose edges are

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -37,6 +37,17 @@ export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyG
   }, Object.create(null));
 }
 
+/**
+ * Removes the specified names from the given dependency graph. The
+ * corresponding properties are deleted and the dependency lists are
+ * updated. The original graph is not modified.
+ *
+ * @param graph The graph to remove plugins from.
+ * @param names The names of the plugins to remove from the graph.
+ * @returns The resulting graph with the given names removed.
+ * @throws If one or more names cannot be removed from the graph without
+ *         breaking a dependency.
+ */
 export function removeFromDependencyGraph(graph: DependencyGraph, names: string[]): DependencyGraph {
   const namesSet = new Set(names);
 

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -32,16 +32,18 @@ function createEmptyGraph(): DependencyGraph {
  * @returns The completed dependency graph.
  */
 export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
-  return plugins.reduce((dependencyGraph, { metadata: { name, depends } }) => {
+  const dependencyGraph = createEmptyGraph();
+
+  plugins.forEach(({ metadata: { name, depends } }) => {
     if (!dependencyGraph[name]) dependencyGraph[name] = [];
 
     depends.forEach((dependency) => {
       if (!dependencyGraph[dependency]) dependencyGraph[dependency] = [];
       dependencyGraph[dependency].push(name);
     });
+  });
 
-    return dependencyGraph;
-  }, createEmptyGraph());
+  return dependencyGraph;
 }
 
 /**

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -21,7 +21,11 @@ export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
 
 export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyGraph {
   return graphs.reduce((merged, graph) => {
-    return Object.assign(merged, graph);
+    Object.keys(graph).forEach((key) => {
+      if (!merged[key]) merged[key] = [];
+      merged[key].push(...graph[key]);
+    });
+    return merged;
   }, Object.create(null));
 }
 

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -2,6 +2,8 @@ import { Plugin } from '../plugin';
 
 export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
   return plugins.reduce((dependencyGraph, { metadata: { name, depends } }) => {
+    if (!dependencyGraph[name]) dependencyGraph[name] = [];
+
     depends.forEach((dependency) => {
       if (!dependencyGraph[dependency]) dependencyGraph[dependency] = [];
       dependencyGraph[dependency].push(name);

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -18,7 +18,7 @@ export interface DependencyGraph {
 /**
  * Creates an empty dependency graph.
  *
- * @returns An empty dependency graph
+ * @returns An empty dependency graph.
  * @hidden
  */
 function createEmptyGraph(): DependencyGraph {

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -19,6 +19,14 @@ export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
   }, Object.create(null));
 }
 
+/**
+ * Deeply merges the given dependency graphs without modifying the
+ * original graphs. When a property exists in more than one graph, the
+ * corresponding arrays are concatenated.
+ *
+ * @param graphs The dependency graphs to merge.
+ * @returns The merged dependency graph.
+ */
 export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyGraph {
   return graphs.reduce((merged, graph) => {
     Object.keys(graph).forEach((key) => {

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,7 +1,14 @@
 import { Plugin } from '../plugin';
 
 export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
-  return Object.create(null);
+  return plugins.reduce((dependencyGraph, { metadata: { name, depends } }) => {
+    depends.forEach((dependency) => {
+      if (!dependencyGraph[dependency]) dependencyGraph[dependency] = [];
+      dependencyGraph[dependency].push(name);
+    });
+
+    return dependencyGraph;
+  }, Object.create(null));
 }
 
 /**

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,14 +1,15 @@
 import { Plugin } from '../plugin';
 
 /**
- * The type of the plugin dependency graph. The dependency graph is a
- * directed graph whose vertices are plugins and whose edges are
- * "depended-on" relations. For example, an edge going from plugin A to
- * plugin B means that A is depended on by B (that is, B depends on A).
+ * The type of a plugin dependency graph. This dependency graph
+ * represents the reverse dependency relationships of the plugins: a
+ * plugin points to the plugins that list it as a dependency. For
+ * example, plugin A will point to plugin B if B lists A as a
+ * dependency.
  *
  * The graph is represented as an adjacency list, which itself is
  * represented as an object whose keys are plugin names and whose values
- * are lists of the names of dependent plugins.
+ * are lists of the names of the depending plugins.
  */
 export interface DependencyGraph {
   /** The names of each plugin's dependers. */

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -6,7 +6,7 @@ import { Plugin } from '../plugin';
  * @param plugins The plugins from which to build the graph.
  * @returns The completed dependency graph.
  */
-export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
+export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
   return plugins.reduce((dependencyGraph, { metadata: { name, depends } }) => {
     if (!dependencyGraph[name]) dependencyGraph[name] = [];
 

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -65,7 +65,8 @@ export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyG
 /**
  * Removes the specified names from the given dependency graph. The
  * corresponding properties are deleted and the dependency lists are
- * updated. The original graph is not modified.
+ * updated. The original graph is not modified. It is safe to attempt to
+ * remove a name that is not in the graph.
  *
  * @param graph The graph to remove plugins from.
  * @param names The names of the plugins to remove from the graph.
@@ -82,7 +83,7 @@ export function removeFromDependencyGraph(graph: DependencyGraph, names: string[
   }, createEmptyGraph());
 
   const errors = names
-    .filter((name) => newGraph[name].length > 0)
+    .filter((name) => newGraph[name] && newGraph[name].length > 0)
     .map((name) => `${name} is required by: ${newGraph[name].join(', ')}.`);
 
   if (errors.length > 0) throw new Error(`Failed to remove dependencies.\n${errors.join('\n')}`);

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,5 +1,11 @@
 import { Plugin } from '../plugin';
 
+/**
+ * Builds a dependency graph from the given plugins.
+ *
+ * @param plugins The plugins from which to build the graph.
+ * @returns The completed dependency graph.
+ */
 export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
   return plugins.reduce((dependencyGraph, { metadata: { name, depends } }) => {
     if (!dependencyGraph[name]) dependencyGraph[name] = [];
@@ -14,9 +20,16 @@ export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
 }
 
 /**
- * The type of the plugin dependency graph. The graph is a mapping from a
- * plugin name to all the names of the plugins that depend on it.
+ * The type of the plugin dependency graph. The dependency graph is a
+ * directed graph whose vertices are plugins and whose edges are
+ * "depended-on" relations. For example, an edge going from plugin A to
+ * plugin B means that A is depended on by B (that is, B depends on A).
+ *
+ * The graph is represented as an adjacency list, which itself is
+ * represented as an object whose keys are plugin names and whose values
+ * are lists of the names of dependent plugins.
  */
 export interface DependencyGraph {
+  /** The names of each plugin's dependents. */
   [name: string]: string[];
 }

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,0 +1,5 @@
+import { Plugin } from '../plugin';
+
+export function createDependencyGraph(plugins: Plugin[]) {
+  return Object.create(null);
+}

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -37,6 +37,10 @@ export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyG
   }, Object.create(null));
 }
 
+export function removeFromDependencyGraph(graph: DependencyGraph, names: string[]): DependencyGraph {
+  return graph;
+}
+
 /**
  * The type of the plugin dependency graph. The dependency graph is a
  * directed graph whose vertices are plugins and whose edges are

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -20,7 +20,9 @@ export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
 }
 
 export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyGraph {
-  return Object.create(null);
+  return graphs.reduce((merged, graph) => {
+    return Object.assign(merged, graph);
+  }, Object.create(null));
 }
 
 /**

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -16,6 +16,15 @@ export interface DependencyGraph {
 }
 
 /**
+ * Creates an empty dependency graph.
+ *
+ * @returns An empty dependency graph
+ */
+function createEmptyGraph(): DependencyGraph {
+  return Object.create(null);
+}
+
+/**
  * Builds a dependency graph from the given plugins.
  *
  * @param plugins The plugins from which to build the graph.
@@ -31,7 +40,7 @@ export function createDependencyGraph(plugins: Plugin[] = []): DependencyGraph {
     });
 
     return dependencyGraph;
-  }, Object.create(null));
+  }, createEmptyGraph());
 }
 
 /**
@@ -49,7 +58,7 @@ export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyG
       merged[key].push(...graph[key]);
     });
     return merged;
-  }, Object.create(null));
+  }, createEmptyGraph());
 }
 
 /**
@@ -69,7 +78,7 @@ export function removeFromDependencyGraph(graph: DependencyGraph, names: string[
   const newGraph = Object.keys(graph).reduce((clone, plugin) => {
     clone[plugin] = graph[plugin].filter((depender) => !namesSet.has(depender));
     return clone;
-  }, Object.create(null));
+  }, createEmptyGraph());
 
   const errors = names
     .filter((name) => newGraph[name].length > 0)

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -19,6 +19,7 @@ export interface DependencyGraph {
  * Creates an empty dependency graph.
  *
  * @returns An empty dependency graph
+ * @hidden
  */
 function createEmptyGraph(): DependencyGraph {
   return Object.create(null);

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,5 +1,13 @@
 import { Plugin } from '../plugin';
 
-export function createDependencyGraph(plugins: Plugin[]) {
+export function createDependencyGraph(plugins: Plugin[]): DependencyGraph {
   return Object.create(null);
+}
+
+/**
+ * The type of the plugin dependency graph. The graph is a mapping from a
+ * plugin name to all the names of the plugins that depend on it.
+ */
+export interface DependencyGraph {
+  [name: string]: string[];
 }

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -1,6 +1,21 @@
 import { Plugin } from '../plugin';
 
 /**
+ * The type of the plugin dependency graph. The dependency graph is a
+ * directed graph whose vertices are plugins and whose edges are
+ * "depended-on" relations. For example, an edge going from plugin A to
+ * plugin B means that A is depended on by B (that is, B depends on A).
+ *
+ * The graph is represented as an adjacency list, which itself is
+ * represented as an object whose keys are plugin names and whose values
+ * are lists of the names of dependent plugins.
+ */
+export interface DependencyGraph {
+  /** The names of each plugin's dependents. */
+  [name: string]: string[];
+}
+
+/**
  * Builds a dependency graph from the given plugins.
  *
  * @param plugins The plugins from which to build the graph.
@@ -65,19 +80,4 @@ export function removeFromDependencyGraph(graph: DependencyGraph, names: string[
   names.forEach((name) => { delete newGraph[name] });
 
   return newGraph;
-}
-
-/**
- * The type of the plugin dependency graph. The dependency graph is a
- * directed graph whose vertices are plugins and whose edges are
- * "depended-on" relations. For example, an edge going from plugin A to
- * plugin B means that A is depended on by B (that is, B depends on A).
- *
- * The graph is represented as an adjacency list, which itself is
- * represented as an object whose keys are plugin names and whose values
- * are lists of the names of dependent plugins.
- */
-export interface DependencyGraph {
-  /** The names of each plugin's dependents. */
-  [name: string]: string[];
 }

--- a/packages/@sfx/core/src/utils/dependencies.ts
+++ b/packages/@sfx/core/src/utils/dependencies.ts
@@ -38,7 +38,21 @@ export function mergeDependencyGraphs(...graphs: DependencyGraph[]): DependencyG
 }
 
 export function removeFromDependencyGraph(graph: DependencyGraph, names: string[]): DependencyGraph {
-  return graph;
+  const newGraph = cloneDependencyGraph(graph);
+
+  names.forEach((name) => {
+    delete newGraph[name];
+  });
+
+  return newGraph;
+}
+
+export function cloneDependencyGraph(graph: DependencyGraph): DependencyGraph {
+  return Object.keys(graph).reduce(
+    (clone, plugin) => {
+      clone[plugin] = [...graph[plugin]];
+      return clone;
+    }, Object.create(null));
 }
 
 /**

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -206,8 +206,8 @@ describe('Core', () => {
     });
 
     it('should clear dependency graph', () => {
-      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
       core.dependencyGraph = { a: ['a'] };
+      stub(CoreUtils, 'unregisterPlugins');
 
       core.unregisterAll();
 

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -19,6 +19,11 @@ describe('Core', () => {
       expect(core.directory).to.be.empty;
       expect(Object.getPrototypeOf(core.directory)).to.be.null;
     });
+
+    it('should create an empty null-prototype plugin dependency graph object', () => {
+      expect(core.dependencyGraph).to.be.empty;
+      expect(Object.getPrototypeOf(core.dependencyGraph)).to.be.null;
+    });
   });
 
   describe('register()', () => {

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -119,6 +119,31 @@ describe('Core', () => {
     });
   });
 
+  describe('unregister()', () => {
+    it('should call unregisterPlugins with the given plugins', () => {
+      const names = ['a', 'c'];
+      const registry = core.registry = {
+        a: { a: 'a' },
+        b: () => /b/,
+        c: 'c',
+      };
+      const directory = core.directory = {
+        a: { metadata: { name: 'a', depends: [] } },
+        b: { metadata: { name: 'b', depends: ['a'] } },
+        c: { metadata: { name: 'c', depends: ['a'] } },
+      } as any;
+      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
+
+      core.unregister(names);
+
+      expect(unregisterPlugins).to.be.calledWith(
+        names,
+        sinon.match.same(registry),
+        sinon.match.same(directory)
+      );
+    });
+  });
+
   describe('unregisterAll()', () => {
     it('should call unregisterPlugins with all plugins', () => {
       const names = ['a', 'b', 'c'];

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -169,6 +169,16 @@ describe('Core', () => {
 
       expect(core.dependencyGraph).to.deep.equal(updatedGraph);
     });
+
+    it('should throw and not unregister plugins if a dependency would be broken', () => {
+      const names = ['a'];
+      removeFromDependencyGraph.throws();
+
+      const callback = () => core.unregister(names);
+
+      expect(callback).to.throw();
+      expect(unregisterPlugins).to.not.be.called;
+    });
   });
 
   describe('unregisterAll()', () => {

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -142,5 +142,14 @@ describe('Core', () => {
         sinon.match.same(directory)
       );
     });
+
+    it('should clear dependency graph', () => {
+      const unregisterPlugins = stub(CoreUtils, 'unregisterPlugins');
+      core.dependencyGraph = { a: ['a'] };
+
+      core.unregisterAll();
+
+      expect(core.dependencyGraph).to.be.empty;
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/core.test.ts
@@ -1,6 +1,7 @@
 import { expect, sinon, stub } from '../../utils';
 import Core from '../../../src/core';
 import * as CoreUtils from '../../../src/utils/core';
+import * as DependencyUtils from '../../../src/utils/dependencies';
 
 describe('Core', () => {
   let core: Core;
@@ -92,6 +93,29 @@ describe('Core', () => {
         initPlugins,
         readyPlugins
       );
+    });
+
+    it('should update the dependency graph', () => {
+      const plugins: any = [
+        {
+          metadata: {
+            name: 'b',
+            depends: [],
+          },
+        },
+      ];
+      const dependencies = core.dependencyGraph = { a: [] };
+      const newDependencies = { b: [] };
+      const mergedDependencies = { a: [], b: [] };
+      const createDependencyGraph = stub(DependencyUtils, 'createDependencyGraph').returns(newDependencies);
+      const mergeDependencyGraphs = stub(DependencyUtils, 'mergeDependencyGraphs').returns(mergedDependencies);
+      calculateMissingDependencies.returns([]);
+
+      core.register(plugins);
+
+      expect(createDependencyGraph).to.be.calledWith(plugins);
+      expect(mergeDependencyGraphs).to.be.calledWith(dependencies, newDependencies);
+      expect(core.dependencyGraph).to.deep.equal(mergedDependencies);
     });
   });
 

--- a/packages/@sfx/core/test/unit/common/utils/core.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/core.test.ts
@@ -476,5 +476,33 @@ describe('CoreUtils', () => {
 
       expect(() => unregisterPlugins(names, registry, directory)).to.not.throw();
     });
+
+    it('should ignore plugins not in the directory', () => {
+      const names = ['a', 'c', 'z'];
+      const bValue = () => /b/;
+      const directory: any = {
+        a: {
+          metadata: { name: 'a' },
+          unregister: () => null,
+        },
+        b: {
+          metadata: { name: 'b' },
+          unregister: () => null,
+        },
+        c: {
+          metadata: { name: 'c' },
+          unregister: () => null,
+        },
+      };
+      const registry: any = {
+        a: { a: 'a' },
+        b: bValue,
+        c: 'c',
+      };
+
+      unregisterPlugins(names, registry, directory);
+
+      expect(registry).to.deep.equal({ b: bValue });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -1,5 +1,6 @@
 import { expect, spy } from '../../../utils';
 import {
+  cloneDependencyGraph,
   createDependencyGraph,
   mergeDependencyGraphs,
   removeFromDependencyGraph,
@@ -167,6 +168,51 @@ describe('DependencyUtils', () => {
         b: ['a', 'c'],
         c: [],
       });
+    });
+
+    it('should return a new graph with the specified dependencies removed', () => {
+      const graph = {
+        a: [],
+        b: ['a', 'c'],
+        c: [],
+        d: [],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, ['a', 'd']);
+
+      expect(newGraph).to.deep.equal({
+        b: ['a', 'c'],
+        c: [],
+      });
+    });
+
+    it('should not modify the original graph', () => {
+      const dependersOfPluginA = [];
+      const graph = {
+        a: dependersOfPluginA,
+        b: ['a', 'c'],
+        c: [],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, ['a']);
+
+      expect(newGraph).not.to.equal(graph);
+      expect(graph.a).to.equal(dependersOfPluginA);
+    });
+  });
+
+  describe('cloneDependencyGraph()', () => {
+    it('should return a deep clone', () => {
+      const original = {
+        a: ['b'],
+        b: [],
+      };
+
+      const clone = cloneDependencyGraph(original);
+
+      expect(clone).to.deep.equal(original);
+      expect(clone.a).not.to.equal(original.a);
+      expect(clone.b).not.to.equal(original.b);
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -1,6 +1,5 @@
 import { expect, spy } from '../../../utils';
 import {
-  cloneDependencyGraph,
   createDependencyGraph,
   mergeDependencyGraphs,
   removeFromDependencyGraph,
@@ -170,6 +169,18 @@ describe('DependencyUtils', () => {
       });
     });
 
+    it('should throw when attempting to remove a plugin that will break a dependency', () => {
+      const graph = {
+        a: ['b'],
+        b: [],
+        c: [],
+      };
+
+      const callback = () => removeFromDependencyGraph(graph, ['a']);
+
+      expect(callback).to.throw();
+    });
+
     it('should return a new graph with the specified dependencies removed', () => {
       const graph = {
         a: [],
@@ -181,7 +192,7 @@ describe('DependencyUtils', () => {
       const newGraph = removeFromDependencyGraph(graph, ['a', 'd']);
 
       expect(newGraph).to.deep.equal({
-        b: ['a', 'c'],
+        b: ['c'],
         c: [],
       });
     });
@@ -229,21 +240,6 @@ describe('DependencyUtils', () => {
       expect(newGraph).to.deep.equal({
         c: [],
       });
-    });
-  });
-
-  describe('cloneDependencyGraph()', () => {
-    it('should return a deep clone', () => {
-      const original = {
-        a: ['b'],
-        b: [],
-      };
-
-      const clone = cloneDependencyGraph(original);
-
-      expect(clone).to.deep.equal(original);
-      expect(clone.a).not.to.equal(original.a);
-      expect(clone.b).not.to.equal(original.b);
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -78,6 +78,22 @@ describe('DependencyUtils', () => {
       expect(Object.getPrototypeOf(merged)).to.be.null;
     });
 
+    it('should "merge" one graph', () => {
+      const first = {
+        a: ['b'],
+        b: [],
+        c: ['c'],
+      };
+
+      const merged = mergeDependencyGraphs(first);
+
+      expect(merged).to.deep.equal({
+        a: ['b'],
+        b: [],
+        c: ['c'],
+      });
+    });
+
     it('should merge disjunct graphs', () => {
       const first = {
         a: ['b'],

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -199,6 +199,37 @@ describe('DependencyUtils', () => {
       expect(newGraph).not.to.equal(graph);
       expect(graph.a).to.equal(dependersOfPluginA);
     });
+
+    it('should remove plugin chains', () => {
+      const graph = {
+        a: ['b'],
+        b: [],
+        c: [],
+        d: ['c'],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, ['a', 'b']);
+
+      expect(newGraph).to.deep.equal({
+        c: [],
+        d: ['c'],
+      });
+    });
+
+    it('should remove circularly dependent plugins', () => {
+      const graph = {
+        a: ['b'],
+        b: ['a'],
+        c: [],
+        d: ['d'],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, ['a', 'b', 'd']);
+
+      expect(newGraph).to.deep.equal({
+        c: [],
+      });
+    });
   });
 
   describe('cloneDependencyGraph()', () => {

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -2,6 +2,7 @@ import { expect, spy } from '../../../utils';
 import {
   createDependencyGraph,
   mergeDependencyGraphs,
+  removeFromDependencyGraph,
 } from '../../../../src/utils/dependencies';
 
 describe('DependencyUtils', () => {
@@ -147,6 +148,24 @@ describe('DependencyUtils', () => {
         d: ['e', 'f'],
         e: [],
         f: [],
+      });
+    });
+  });
+
+  describe('removeFromDependencyGraph()', () => {
+    it('should remove nothing given no plugin names', () => {
+      const graph = {
+        a: [],
+        b: ['a', 'c'],
+        c: [],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, []);
+
+      expect(newGraph).to.deep.equal({
+        a: [],
+        b: ['a', 'c'],
+        c: [],
       });
     });
   });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -241,5 +241,18 @@ describe('DependencyUtils', () => {
         c: [],
       });
     });
+
+    it('should ignore plugins that are not present', () => {
+      const graph = {
+        a: ['b'],
+        b: [],
+      };
+
+      const newGraph = removeFromDependencyGraph(graph, ['b', 'z']);
+
+      expect(newGraph).to.deep.equal({
+        a: [],
+      });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -73,9 +73,9 @@ describe('DependencyUtils', () => {
 
   describe('mergeDependencyGraphs()', () => {
     it('should return an object without inherited properties', () => {
-      const dependencies = mergeDependencyGraphs();
+      const merged = mergeDependencyGraphs();
 
-      expect(Object.getPrototypeOf(dependencies)).to.be.null;
+      expect(Object.getPrototypeOf(merged)).to.be.null;
     });
 
     it('should merge disjunct graphs', () => {

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -6,7 +6,7 @@ import {
 describe('DependencyUtils', () => {
   describe('createDependencyGraph()', () => {
     it('should return an object without inherited properties', () => {
-      const dependencies = createDependencyGraph([]);
+      const dependencies = createDependencyGraph();
 
       expect(Object.getPrototypeOf(dependencies)).to.be.null;
     });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -13,5 +13,17 @@ describe('DependencyUtils', () => {
       expect(dependencies).to.deep.equal({});
       expect(Object.getPrototypeOf(dependencies)).to.be.null;
     });
+
+    it('should create an empty object when given plugins with no dependencies', () => {
+      const plugins: any = [
+        { metadata: { name: 'a', depends: [] } },
+        { metadata: { name: 'b', depends: [] } },
+        { metadata: { name: 'c', depends: [] } },
+      ];
+
+      const dependencies = createDependencyGraph(plugins);
+
+      expect(dependencies).to.deep.equal({});
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -5,13 +5,18 @@ import {
 
 describe('DependencyUtils', () => {
   describe('createDependencyGraph()', () => {
-    it('should return an empty dictionary object given an empty array', () => {
+    it('should return an object without inherited properties', () => {
+      const dependencies = createDependencyGraph([]);
+
+      expect(Object.getPrototypeOf(dependencies)).to.be.null;
+    });
+
+    it('should return an empty object given an empty array', () => {
       const plugins = [];
 
       const dependencies = createDependencyGraph(plugins);
 
       expect(dependencies).to.deep.equal({});
-      expect(Object.getPrototypeOf(dependencies)).to.be.null;
     });
 
     it('should create an empty object when given plugins with no dependencies', () => {

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -30,5 +30,20 @@ describe('DependencyUtils', () => {
 
       expect(dependencies).to.deep.equal({});
     });
+
+    it('should create an object with a mapping from a dependency to the names of the plugins that depend on it', () => {
+      const plugins: any = [
+        { metadata: { name: 'a', depends: ['a_dep'] } },
+        { metadata: { name: 'b', depends: ['b_dep', 'a_dep'] } },
+        { metadata: { name: 'c', depends: [] } },
+      ];
+
+      const dependencies = createDependencyGraph(plugins);
+
+      expect(dependencies).to.deep.equal({
+        a_dep: ['a', 'b'],
+        b_dep: ['b'],
+      });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -52,5 +52,21 @@ describe('DependencyUtils', () => {
         b_dep: ['b'],
       });
     });
+
+    it('should support circular dependencies', () => {
+      const plugins: any = [
+        { metadata: { name: 'a', depends: ['b'] } },
+        { metadata: { name: 'b', depends: ['a'] } },
+        { metadata: { name: 'c', depends: ['c'] } },
+      ];
+
+      const dependencies = createDependencyGraph(plugins);
+
+      expect(dependencies).to.deep.equal({
+        a: ['b'],
+        b: ['a'],
+        c: ['c'],
+      });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -102,5 +102,36 @@ describe('DependencyUtils', () => {
         f: [],
       });
     });
+
+    it('should merge the values of non-disjunct graphs', () => {
+      const first = {
+        a: ['b'],
+        b: [],
+        c: ['c'],
+      };
+      const second = {
+        a: ['d'],
+        d: ['e', 'f'],
+        e: [],
+      };
+      const third = {};
+      const fourth = {
+        a: ['f'],
+        b: [],
+        d: [],
+        f: [],
+      };
+
+      const merged = mergeDependencyGraphs(first, second, third, fourth);
+
+      expect(merged).to.deep.equal({
+        a: ['b', 'd', 'f'],
+        b: [],
+        c: ['c'],
+        d: ['e', 'f'],
+        e: [],
+        f: [],
+      });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -19,7 +19,7 @@ describe('DependencyUtils', () => {
       expect(dependencies).to.deep.equal({});
     });
 
-    it('should create an empty object when given plugins with no dependencies', () => {
+    it('should include names of the plugins passed in as terminal nodes', () => {
       const plugins: any = [
         { metadata: { name: 'a', depends: [] } },
         { metadata: { name: 'b', depends: [] } },
@@ -28,10 +28,14 @@ describe('DependencyUtils', () => {
 
       const dependencies = createDependencyGraph(plugins);
 
-      expect(dependencies).to.deep.equal({});
+      expect(dependencies).to.deep.equal({
+        a: [],
+        b: [],
+        c: [],
+      });
     });
 
-    it('should create an object with a mapping from a dependency to the names of the plugins that depend on it', () => {
+    it('should include the names of the dependencies as non-terminal nodes', () => {
       const plugins: any = [
         { metadata: { name: 'a', depends: ['a_dep'] } },
         { metadata: { name: 'b', depends: ['b_dep', 'a_dep'] } },
@@ -41,6 +45,9 @@ describe('DependencyUtils', () => {
       const dependencies = createDependencyGraph(plugins);
 
       expect(dependencies).to.deep.equal({
+        a: [],
+        b: [],
+        c: [],
         a_dep: ['a', 'b'],
         b_dep: ['b'],
       });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -1,6 +1,7 @@
 import { expect, spy } from '../../../utils';
 import {
   createDependencyGraph,
+  mergeDependencyGraphs,
 } from '../../../../src/utils/dependencies';
 
 describe('DependencyUtils', () => {
@@ -67,6 +68,14 @@ describe('DependencyUtils', () => {
         b: ['a'],
         c: ['c'],
       });
+    });
+  });
+
+  describe('mergeDependencyGraphs()', () => {
+    it('should return an object without inherited properties', () => {
+      const dependencies = mergeDependencyGraphs();
+
+      expect(Object.getPrototypeOf(dependencies)).to.be.null;
     });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -199,16 +199,17 @@ describe('DependencyUtils', () => {
 
     it('should not modify the original graph', () => {
       const dependersOfPluginA = [];
-      const graph = {
+      const originalGraph = {
         a: dependersOfPluginA,
         b: ['a', 'c'],
         c: [],
       };
 
-      const newGraph = removeFromDependencyGraph(graph, ['a']);
+      const newGraph = removeFromDependencyGraph(originalGraph, ['a']);
 
-      expect(newGraph).not.to.equal(graph);
-      expect(graph.a).to.equal(dependersOfPluginA);
+      expect(newGraph).not.to.equal(originalGraph);
+      expect(originalGraph.a).to.equal(dependersOfPluginA);
+      expect(newGraph).not.to.have.any.keys('a');
     });
 
     it('should remove plugin chains', () => {

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -77,5 +77,30 @@ describe('DependencyUtils', () => {
 
       expect(Object.getPrototypeOf(dependencies)).to.be.null;
     });
+
+    it('should merge disjunct graphs', () => {
+      const first = {
+        a: ['b'],
+        b: [],
+        c: ['c'],
+      };
+      const second = {
+        d: ['e', 'f'],
+        e: [],
+        f: [],
+      };
+      const third = {};
+
+      const merged = mergeDependencyGraphs(first, second, third);
+
+      expect(merged).to.deep.equal({
+        a: ['b'],
+        b: [],
+        c: ['c'],
+        d: ['e', 'f'],
+        e: [],
+        f: [],
+      });
+    });
   });
 });

--- a/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
+++ b/packages/@sfx/core/test/unit/common/utils/dependencies.test.ts
@@ -1,0 +1,17 @@
+import { expect, spy } from '../../../utils';
+import {
+  createDependencyGraph,
+} from '../../../../src/utils/dependencies';
+
+describe('DependencyUtils', () => {
+  describe('createDependencyGraph()', () => {
+    it('should return an empty dictionary object given an empty array', () => {
+      const plugins = [];
+
+      const dependencies = createDependencyGraph(plugins);
+
+      expect(dependencies).to.deep.equal({});
+      expect(Object.getPrototypeOf(dependencies)).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
A new method `Core.unregister` has been added to unregister a subset of plugins. It takes in a list of plugins to unregister and unregisters them. A new dependency graph structure has been added to keep track of dependency relationships, and `Core.register` has been modified to populate that graph. The graph is represented as an adjacency list, where the keys are plugin names and the values are arrays of dependers. A number of dependency graph-related helper functions have also been created.