### PR TITLE
SFX-354: Update search driver for searchbox IDs

### DIFF
--- a/packages/@sfx/sayt-driver-plugin/CHANGELOG.md
+++ b/packages/@sfx/sayt-driver-plugin/CHANGELOG.md
@@ -8,5 +8,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SFX-160: Added the `SaytDriverPlugin` module.
   - The `SaytDriverPlugin` module acts as a mediator between the Logic and View layers for prebuilt modules.
-  - SFX-295: Added the associated searchbox ID to response events.
+  - SFX-295: Added the associated group ID to response events.
   - SFX-333: Added retrieval and event emission of products.

--- a/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
+++ b/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
@@ -112,13 +112,13 @@ export default class SaytDriverPlugin implements Plugin {
    * @param event Event that contains the Sayt API request payload.
    */
   fetchAutocompleteTerms(event: CustomEvent<AutocompleteRequestConfig>) {
-    const { query, searchbox, config } = event.detail;
+    const { query, group, config } = event.detail;
     this.sendAutocompleteApiRequest(query, config)
       .then((results) => {
-        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteResponseEvent, { results, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteResponseEvent, { results, group });
       })
       .catch((error) => {
-        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, { error, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, { error, group });
       });
   }
 
@@ -129,13 +129,13 @@ export default class SaytDriverPlugin implements Plugin {
    * @param event Event that contains the Search API request payload.
    */
   fetchProductData(event: CustomEvent<SearchRequestConfig>) {
-    const { query, searchbox, config } = event.detail;
+    const { query, group, config } = event.detail;
     this.sendSearchApiRequest(query, config)
       .then(results => {
-        this.core[this.eventsPluginName].dispatchEvent(this.productResponseEvent, { results, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(this.productResponseEvent, { results, group });
       })
       .catch(error => {
-        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, { error, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, { error, group });
       });
   }
 
@@ -250,7 +250,7 @@ export default class SaytDriverPlugin implements Plugin {
  */
 export interface RequestConfig<T> {
   query: string;
-  searchbox?: string;
+  group?: string;
   config?: T;
 }
 

--- a/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
+++ b/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
@@ -118,7 +118,7 @@ export default class SaytDriverPlugin implements Plugin {
         this.core[this.eventsPluginName].dispatchEvent(this.autocompleteResponseEvent, { results, searchbox });
       })
       .catch((e) => {
-        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, e);
+        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, { e, searchbox });
       });
   }
 
@@ -135,7 +135,7 @@ export default class SaytDriverPlugin implements Plugin {
         this.core[this.eventsPluginName].dispatchEvent(this.productResponseEvent, { results, searchbox });
       })
       .catch(e => {
-        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, e);
+        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, { e, searchbox });
       });
   }
 

--- a/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
+++ b/packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts
@@ -117,8 +117,8 @@ export default class SaytDriverPlugin implements Plugin {
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(this.autocompleteResponseEvent, { results, searchbox });
       })
-      .catch((e) => {
-        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, { e, searchbox });
+      .catch((error) => {
+        this.core[this.eventsPluginName].dispatchEvent(this.autocompleteErrorEvent, { error, searchbox });
       });
   }
 
@@ -134,8 +134,8 @@ export default class SaytDriverPlugin implements Plugin {
       .then(results => {
         this.core[this.eventsPluginName].dispatchEvent(this.productResponseEvent, { results, searchbox });
       })
-      .catch(e => {
-        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, { e, searchbox });
+      .catch(error => {
+        this.core[this.eventsPluginName].dispatchEvent(this.productErrorEvent, { error, searchbox });
       });
   }
 

--- a/packages/@sfx/sayt-driver-plugin/test/unit/common/sayt-driver-plugin.test.ts
+++ b/packages/@sfx/sayt-driver-plugin/test/unit/common/sayt-driver-plugin.test.ts
@@ -31,14 +31,14 @@ describe('Sayt Driver Plugin', () => {
       detail: {
         query,
         config,
-        searchbox: 'some-searchbox-id',
+        group: 'some-group-id',
       },
     };
     productDataPayload = {
       detail: {
         query,
         config,
-        searchbox: 'some-searchbox-id',
+        group: 'some-group-id',
       },
     };
   });
@@ -245,7 +245,7 @@ describe('Sayt Driver Plugin', () => {
   describe('fetchAutocompleteTerms()', () => {
     let dispatchEvent;
     let results;
-    let searchbox;
+    let group;
     let sendAutocompleteApiRequest;
 
     beforeEach(() => {
@@ -255,7 +255,7 @@ describe('Sayt Driver Plugin', () => {
       };
       results =  { a: 'b' };
       sendAutocompleteApiRequest = stub(driver, 'sendAutocompleteApiRequest');
-      searchbox = 'some-searchbox-id';
+      group = 'some-group-id';
     });
 
     it('should call sendAutocompleteApiRequest with query from event and valid config', () => {
@@ -272,7 +272,7 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchAutocompleteTerms(saytDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.autocompleteResponseEvent, { results, searchbox });
+        .to.be.eventually.calledOnceWith(driver.autocompleteResponseEvent, { results, group });
     });
 
     it('should send an error in an event if the API request fails', () => {
@@ -282,14 +282,14 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchAutocompleteTerms(saytDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.autocompleteErrorEvent, { error, searchbox });
+        .to.be.eventually.calledOnceWith(driver.autocompleteErrorEvent, { error, group });
     });
   });
 
   describe('fetchProductData()', () => {
     let dispatchEvent;
     let results;
-    let searchbox;
+    let group;
     let sendSearchApiRequest;
 
     beforeEach(() => {
@@ -299,7 +299,7 @@ describe('Sayt Driver Plugin', () => {
       };
       results = { a: 'b' };
       sendSearchApiRequest = stub(driver, 'sendSearchApiRequest');
-      searchbox = 'some-searchbox-id';
+      group = 'some-group-id';
     });
 
     it('should call sendSearchApiRequest with query from event and valid config', () => {
@@ -316,7 +316,7 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchProductData(productDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.productResponseEvent, { results, searchbox });
+        .to.be.eventually.calledOnceWith(driver.productResponseEvent, { results, group });
     });
 
     it('should send an error in an event if the API request fails', () => {
@@ -326,7 +326,7 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchProductData(saytDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.productErrorEvent, { error, searchbox });
+        .to.be.eventually.calledOnceWith(driver.productErrorEvent, { error, group });
     });
   });
 

--- a/packages/@sfx/sayt-driver-plugin/test/unit/common/sayt-driver-plugin.test.ts
+++ b/packages/@sfx/sayt-driver-plugin/test/unit/common/sayt-driver-plugin.test.ts
@@ -282,7 +282,7 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchAutocompleteTerms(saytDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.autocompleteErrorEvent, error);
+        .to.be.eventually.calledOnceWith(driver.autocompleteErrorEvent, { error, searchbox });
     });
   });
 
@@ -326,7 +326,7 @@ describe('Sayt Driver Plugin', () => {
       driver.fetchProductData(saytDataPayload);
 
       return expect(Promise.resolve(dispatchEvent))
-        .to.be.eventually.calledOnceWith(driver.productErrorEvent, error);
+        .to.be.eventually.calledOnceWith(driver.productErrorEvent, { error, searchbox });
     });
   });
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -83,8 +83,8 @@ export default class SearchDriverPlugin implements Plugin {
       .then((results) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, { results, searchbox });
       })
-      .catch((e) => {
-        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, { e, searchbox });
+      .catch((error) => {
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, { error, searchbox });
       });
   }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -78,13 +78,13 @@ export default class SearchDriverPlugin implements Plugin {
    * @param event the event whose payload is the search term.
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
-    const { value: searchTerm, searchbox } = event.detail;
+    const { value: searchTerm, group } = event.detail;
     this.sendSearchApiRequest(searchTerm)
       .then((results) => {
-        this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, { results, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, { results, group });
       })
       .catch((error) => {
-        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, { error, searchbox });
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, { error, group });
       });
   }
 
@@ -105,5 +105,5 @@ export default class SearchDriverPlugin implements Plugin {
  */
 export interface SearchRequestPayload {
   value: string;
-  searchbox?: string;
+  group?: string;
 }

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -84,7 +84,7 @@ export default class SearchDriverPlugin implements Plugin {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, { results, searchbox });
       })
       .catch((e) => {
-        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, { e, searchbox });
       });
   }
 

--- a/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts
@@ -78,10 +78,10 @@ export default class SearchDriverPlugin implements Plugin {
    * @param event the event whose payload is the search term.
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
-    const searchTerm = event.detail.value;
+    const { value: searchTerm, searchbox } = event.detail;
     this.sendSearchApiRequest(searchTerm)
       .then((results) => {
-        this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, results);
+        this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE_EVENT, { results, searchbox });
       })
       .catch((e) => {
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_ERROR_EVENT, e);

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -64,7 +64,7 @@ describe('SearchDriverPlugin', () => {
     });
   });
 
-  describe('fetchSearchData()', () => {
+  describe.only('fetchSearchData()', () => {
     it('should search with the given search term', () => {
       const searchTerm = 'search term';
       const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves();
@@ -77,10 +77,11 @@ describe('SearchDriverPlugin', () => {
       expect(sendSearchApiRequest).to.be.calledWith(searchTerm);
     });
 
-    it('should dispatch an event with the results', (done) => {
+    it('should dispatch an event with the results and the searchbox if present', (done) => {
       const results = { a: 'a' };
+      const searchbox = 'searchbox';
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, results);
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox });
         done();
       });
       const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves(results);
@@ -88,7 +89,21 @@ describe('SearchDriverPlugin', () => {
         [eventsPluginName]: { dispatchEvent },
       };
 
-      searchDriverPlugin.fetchSearchData({ detail: 'search' } as any);
+      searchDriverPlugin.fetchSearchData({ detail: { value: 'search', searchbox } } as any);
+    });
+
+    it('should send an undefined searchbox if one is not provided', (done) => {
+      const results = { a: 'a' };
+      const dispatchEvent = spy(() => {
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox: undefined });
+        done();
+      });
+      const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves(results);
+      searchDriverPlugin.core = {
+        [eventsPluginName]: { dispatchEvent },
+      };
+
+      searchDriverPlugin.fetchSearchData({ detail: { value: 'search' } } as any);
     });
 
     it('should dispatch an error event when the search fails', (done) => {

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -65,9 +65,19 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('fetchSearchData()', () => {
+    let results;
+    let searchbox;
+    let sendSearchApiRequest;
+
+    beforeEach(() => {
+      results = { a: 'a' };
+      searchbox = undefined;
+      sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest');
+    });
+
     it('should search with the given search term', () => {
       const searchTerm = 'search term';
-      const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves();
+      sendSearchApiRequest.resolves();
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent: () => {} },
       };
@@ -78,13 +88,12 @@ describe('SearchDriverPlugin', () => {
     });
 
     it('should dispatch an event with the results and the searchbox if present', (done) => {
-      const results = { a: 'a' };
-      const searchbox = 'searchbox';
       const dispatchEvent = spy(() => {
         expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox });
         done();
       });
-      const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves(results);
+      searchbox = 'searchbox';
+      sendSearchApiRequest.resolves(results);
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent },
       };
@@ -93,12 +102,11 @@ describe('SearchDriverPlugin', () => {
     });
 
     it('should send an undefined searchbox if one is not provided', (done) => {
-      const results = { a: 'a' };
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox: undefined });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox });
         done();
       });
-      const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves(results);
+      sendSearchApiRequest.resolves(results);
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent },
       };
@@ -108,11 +116,11 @@ describe('SearchDriverPlugin', () => {
 
     it('should dispatch an error event when the search fails', (done) => {
       const error = new Error('error-object');
-      const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').rejects(error);
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_ERROR_EVENT, error);
+        expect(dispatchEvent).to.be.calledWith(SEARCH_ERROR_EVENT, { error, searchbox });
         done();
       });
+      sendSearchApiRequest.rejects(error);
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent },
       };

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -64,7 +64,7 @@ describe('SearchDriverPlugin', () => {
     });
   });
 
-  describe.only('fetchSearchData()', () => {
+  describe('fetchSearchData()', () => {
     it('should search with the given search term', () => {
       const searchTerm = 'search term';
       const sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest').resolves();

--- a/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@sfx/search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -66,12 +66,12 @@ describe('SearchDriverPlugin', () => {
 
   describe('fetchSearchData()', () => {
     let results;
-    let searchbox;
+    let group;
     let sendSearchApiRequest;
 
     beforeEach(() => {
       results = { a: 'a' };
-      searchbox = undefined;
+      group = undefined;
       sendSearchApiRequest = stub(searchDriverPlugin, 'sendSearchApiRequest');
     });
 
@@ -87,23 +87,23 @@ describe('SearchDriverPlugin', () => {
       expect(sendSearchApiRequest).to.be.calledWith(searchTerm);
     });
 
-    it('should dispatch an event with the results and the searchbox if present', (done) => {
+    it('should dispatch an event with the results and the group if present', (done) => {
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, group });
         done();
       });
-      searchbox = 'searchbox';
+      group = 'group';
       sendSearchApiRequest.resolves(results);
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent },
       };
 
-      searchDriverPlugin.fetchSearchData({ detail: { value: 'search', searchbox } } as any);
+      searchDriverPlugin.fetchSearchData({ detail: { value: 'search', group } } as any);
     });
 
-    it('should send an undefined searchbox if one is not provided', (done) => {
+    it('should send an undefined group if one is not provided', (done) => {
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, searchbox });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE_EVENT, { results, group });
         done();
       });
       sendSearchApiRequest.resolves(results);
@@ -117,7 +117,7 @@ describe('SearchDriverPlugin', () => {
     it('should dispatch an error event when the search fails', (done) => {
       const error = new Error('error-object');
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_ERROR_EVENT, { error, searchbox });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_ERROR_EVENT, { error, group });
         done();
       });
       sendSearchApiRequest.rejects(error);


### PR DESCRIPTION
The search driver is receiving an optional searchbox ID in search requests. This value should be returned in the product response events that the search driver sends.