### PR TITLE
Add eslintrc to test directories

### DIFF
--- a/packages/@sfx/core/test/.eslintrc.js
+++ b/packages/@sfx/core/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@sfx/dom-events-plugin/test/.eslintrc.js
+++ b/packages/@sfx/dom-events-plugin/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@sfx/sayt-driver-plugin/test/.eslintrc.js
+++ b/packages/@sfx/sayt-driver-plugin/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@sfx/sayt-plugin/test/.eslintrc.js
+++ b/packages/@sfx/sayt-plugin/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@sfx/search-driver-plugin/test/.eslintrc.js
+++ b/packages/@sfx/search-driver-plugin/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@sfx/search-plugin/test/.eslintrc.js
+++ b/packages/@sfx/search-plugin/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;


### PR DESCRIPTION
This makes local tools use the test-specific eslint settings while
working with the tests.